### PR TITLE
Do not raise an exception if no arguments are given

### DIFF
--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -114,7 +114,10 @@ module GitFastClone
         end
       end.parse!
 
-      fail usage unless ARGV[0]
+      unless ARGV[0]
+        STDERR.puts usage
+        exit(129)
+      end
 
       if Dir.exist?(ARGV[0])
         url = File.expand_path ARGV[0]


### PR DESCRIPTION
Align with "git clone" in that specifying no arguments just prints the
usage to STDERR, and exit with code 129.