### PR TITLE
Avoid corrupting the mirror repo cache.

### DIFF
--- a/spec/git_fastclone_runner_spec.rb
+++ b/spec/git_fastclone_runner_spec.rb
@@ -203,13 +203,13 @@ describe GitFastClone::Runner do
   describe '.store_updated_repo' do
     context 'when fail_hard is true' do
       it 'should raise a Cocaine error' do
-        pending('TODO: Fix later')
-        fail
-=begin
+        cocaine_commandline_double = double('new_cocaine_commandline')
+        allow(cocaine_commandline_double).to receive(:run) { fail Cocaine::ExitStatusError }
+        allow(Cocaine::CommandLine).to receive(:new) { cocaine_commandline_double }
+        expect(FileUtils).to receive(:remove_entry_secure).with(placeholder_arg, force: true)
         expect do
           subject.store_updated_repo(placeholder_arg, placeholder_arg, placeholder_arg, true)
         end.to raise_error(Cocaine::ExitStatusError)
-=end
       end
     end
 
@@ -218,10 +218,11 @@ describe GitFastClone::Runner do
         cocaine_commandline_double = double('new_cocaine_commandline')
         allow(cocaine_commandline_double).to receive(:run) { fail Cocaine::ExitStatusError }
         allow(Cocaine::CommandLine).to receive(:new) { cocaine_commandline_double }
+        expect(FileUtils).to receive(:remove_entry_secure).with(placeholder_arg, force: true)
 
         expect do
           subject.store_updated_repo(placeholder_arg, placeholder_arg, placeholder_arg, false)
-        end.not_to raise_error(Cocaine::ExitStatusError)
+        end.not_to raise_error
       end
     end
 


### PR DESCRIPTION
We do this by removing the cache for a git repo entirely if
its creation or update fails.

Also fixed the related tests up a bit.