### PR TITLE
Run 'bundle update rubocop' to fix CVE-2017-8418

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,9 +13,7 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    ast (2.2.0)
-    astrolabe (1.3.1)
-      parser (~> 2.2)
+    ast (2.4.0)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cocaine (0.5.8)
@@ -26,10 +24,11 @@ GEM
     i18n (0.7.0)
     logger (1.2.8)
     minitest (5.10.1)
-    parser (2.2.3.0)
-      ast (>= 1.1, < 3.0)
+    parallel (1.12.1)
+    parser (2.5.0.5)
+      ast (~> 2.4.0)
     powerpack (0.1.1)
-    rainbow (2.0.0)
+    rainbow (3.0.0)
     rake (10.4.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
@@ -44,18 +43,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    rubocop (0.35.1)
-      astrolabe (~> 1.3)
-      parser (>= 2.2.3.0, < 3.0)
+    rubocop (0.54.0)
+      parallel (~> 1.10)
+      parser (>= 2.5)
       powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      tins (<= 1.6.0)
-    ruby-progressbar (1.7.5)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.9.0)
     thread_safe (0.3.5)
-    tins (1.6.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unicode-display_width (1.3.0)
 
 PLATFORMS
   ruby
@@ -69,4 +68,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.13.6
+   1.16.1

--- a/git-fastclone.gemspec
+++ b/git-fastclone.gemspec
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'date'
+
 $:.push File.expand_path("../lib", __FILE__)
 require 'git-fastclone/version'
 


### PR DESCRIPTION
Run 'bundle update rubocop' to fix CVE-2017-8418 @longboardcat