### PR TITLE
Retry when deltas are missing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,7 @@ Metrics/LineLength:
 
 Metrics/MethodLength:
   Max: 2000
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git-fastclone (1.2.1)
+    git-fastclone (1.2.2)
       colorize
       terrapin (~> 0.6.0)
 

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -352,7 +352,12 @@ module GitFastClone
         begin
           yield dir
         rescue Terrapin::ExitStatusError => e
-          if e.to_s =~ /^STDERR:\n.+^fatal: (missing blob object|remote did not send all necessary objects)/m
+          error_strings = [
+            'missing blob object',
+            'remote did not send all necessary objects',
+            /pack has \d+ unresolved deltas/
+          ]
+          if e.to_s =~ /^STDERR:\n.+^fatal: #{Regexp.union(error_strings)}/m
             # To avoid corruption of the cache, if we failed to update or check out we remove
             # the cache directory entirely. This may cause the current clone to fail, but if the
             # underlying error from git is transient it will not affect future clones.

--- a/lib/git-fastclone/version.rb
+++ b/lib/git-fastclone/version.rb
@@ -2,5 +2,5 @@
 
 # Version string for git-fastclone
 module GitFastCloneVersion
-  VERSION = '1.2.1'.freeze
+  VERSION = '1.2.2'.freeze
 end

--- a/spec/git_fastclone_runner_spec.rb
+++ b/spec/git_fastclone_runner_spec.rb
@@ -305,5 +305,32 @@ describe GitFastClone::Runner do
       expect(responses).to be_empty
       expect(yielded).to eq([test_url_valid])
     end
+
+    it 'should retry when deltas are missing' do
+      allow(subject).to receive(:update_reference_repo) {}
+      expect(subject).to receive(:reference_repo_dir)
+      expect(subject).to receive(:reference_repo_lock_file).and_return(lockfile)
+
+      responses = [
+        lambda { |_url|
+          raise Terrapin::ExitStatusError, <<-ERROR.gsub(/^ {12}/, '')
+            STDOUT:
+
+            STDERR:
+
+            error: Could not read f7fad86d06fee0678f9af7203b6031feabb40c3e
+            fatal: pack has 138063 unresolved deltas
+            fatal: index-pack failed
+          ERROR
+        },
+        ->(url) { url }
+      ]
+      subject.with_git_mirror(test_url_valid) do
+        yielded << responses.shift.call(test_url_valid)
+      end
+
+      expect(responses).to be_empty
+      expect(yielded).to eq([test_url_valid])
+    end
   end
 end


### PR DESCRIPTION
This error is another symptom of a broken cache and should be
handled the same way as the rest of our broken cache mitigation.