### PR TITLE
Blow away cache and retry when reading tree fails after clone

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git-fastclone (1.2.6)
+    git-fastclone (1.2.7)
       colorize
       terrapin (~> 0.6.0)
 

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -358,7 +358,8 @@ module GitFastClone
             /fatal: packed object [a-z0-9]+ \(stored in .*?\) is corrupt/,
             /fatal: pack has \d+ unresolved delta/,
             'error: unable to read sha1 file of ',
-            'fatal: did not receive expected object'
+            'fatal: did not receive expected object',
+            /^fatal: unable to read tree [a-z0-9]+\n^warning: Clone succeeded, but checkout failed/
           ]
           if e.to_s =~ /^STDERR:\n.+^#{Regexp.union(error_strings)}/m
             # To avoid corruption of the cache, if we failed to update or check out we remove

--- a/lib/git-fastclone/version.rb
+++ b/lib/git-fastclone/version.rb
@@ -2,5 +2,5 @@
 
 # Version string for git-fastclone
 module GitFastCloneVersion
-  VERSION = '1.2.6'.freeze
+  VERSION = '1.2.7'.freeze
 end


### PR DESCRIPTION
This seems to indicate bad state in the reference repo, as it persists through retries with the same cache, and happens non-deterministically