### PR TITLE
Introduce --config parameter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git-fastclone (1.2.8)
+    git-fastclone (1.3.0)
       colorize
       terrapin (~> 0.6.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git-fastclone (1.2.7)
+    git-fastclone (1.2.8)
       colorize
       terrapin (~> 0.6.0)
 

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -148,7 +148,7 @@ module GitFastClone
           self.color = true
         end
 
-        opts.on('--config CONFIG', 'Git config applied to the cloned repo')  do |config|
+        opts.on('--config CONFIG', 'Git config applied to the cloned repo') do |config|
           options[:config] = config
         end
 
@@ -196,7 +196,7 @@ module GitFastClone
 
       with_git_mirror(url) do |mirror|
         clone_command = '--quiet --reference :mirror :url :path'
-        clone_command += " --config :config" unless config.nil?
+        clone_command += ' --config :config' unless config.nil?
         Terrapin::CommandLine.new('git clone', clone_command)
                              .run(mirror: mirror.to_s,
                                   url: url.to_s,

--- a/lib/git-fastclone/version.rb
+++ b/lib/git-fastclone/version.rb
@@ -2,5 +2,5 @@
 
 # Version string for git-fastclone
 module GitFastCloneVersion
-  VERSION = '1.2.7'.freeze
+  VERSION = '1.2.8'.freeze
 end

--- a/lib/git-fastclone/version.rb
+++ b/lib/git-fastclone/version.rb
@@ -2,5 +2,5 @@
 
 # Version string for git-fastclone
 module GitFastCloneVersion
-  VERSION = '1.2.8'.freeze
+  VERSION = '1.3.0'.freeze
 end

--- a/spec/git_fastclone_runner_spec.rb
+++ b/spec/git_fastclone_runner_spec.rb
@@ -103,13 +103,13 @@ describe GitFastClone::Runner do
         'git checkout',
         '--quiet :rev'
       ) { terrapin_commandline_double }
-      expect(terrapin_commandline_double).to receive(:run).with({
-                                                                  mirror: '/cache',
-                                                                  url: placeholder_arg,
-                                                                  path: '/pwd/.',
-                                                                  config: ''
-                                                                })
-      expect(terrapin_commandline_double).to receive(:run).with({ rev: placeholder_arg })
+      expect(terrapin_commandline_double).to receive(:run).with(
+        mirror: '/cache',
+        url: placeholder_arg,
+        path: '/pwd/.',
+        config: ''
+      )
+      expect(terrapin_commandline_double).to receive(:run).with(rev: placeholder_arg)
 
       subject.clone(placeholder_arg, placeholder_arg, '.', nil)
     end
@@ -120,12 +120,12 @@ describe GitFastClone::Runner do
           'git clone',
           '--quiet --reference :mirror :url :path --config :config'
         ) { terrapin_commandline_double }
-        expect(terrapin_commandline_double).to receive(:run).with({
-                                                                    mirror: '/cache',
-                                                                    url: placeholder_arg,
-                                                                    path: '/pwd/.',
-                                                                    config: 'config'
-                                                                  })
+        expect(terrapin_commandline_double).to receive(:run).with(
+          mirror: '/cache',
+          url: placeholder_arg,
+          path: '/pwd/.',
+          config: 'config'
+        )
 
         subject.clone(placeholder_arg, nil, '.', 'config')
       end

--- a/spec/git_fastclone_runner_spec.rb
+++ b/spec/git_fastclone_runner_spec.rb
@@ -56,10 +56,21 @@ describe GitFastClone::Runner do
     let(:options) { { branch: placeholder_arg } }
 
     it 'should run with the correct args' do
-      allow(subject).to receive(:parse_inputs) { [placeholder_arg, placeholder_arg, options] }
-      expect(subject).to receive(:clone).with(placeholder_arg, placeholder_arg, placeholder_arg)
+      allow(subject).to receive(:parse_inputs) { [placeholder_arg, placeholder_arg, options, nil] }
+      expect(subject).to receive(:clone).with(placeholder_arg, placeholder_arg, placeholder_arg, nil)
 
       subject.run
+    end
+
+    describe 'with custom configs' do
+      let(:options) { { branch: placeholder_arg, config: 'conf' } }
+
+      it 'should clone correctly' do
+        allow(subject).to receive(:parse_inputs) { [placeholder_arg, placeholder_arg, options, 'conf'] }
+        expect(subject).to receive(:clone).with(placeholder_arg, placeholder_arg, placeholder_arg, 'conf')
+
+        subject.run
+      end
     end
   end
 
@@ -84,7 +95,7 @@ describe GitFastClone::Runner do
       expect(Terrapin::CommandLine).to receive(:new)
       expect(terrapin_commandline_double).to receive(:run)
 
-      subject.clone(placeholder_arg, placeholder_arg, '.')
+      subject.clone(placeholder_arg, placeholder_arg, '.', nil)
     end
   end
 

--- a/spec/git_fastclone_runner_spec.rb
+++ b/spec/git_fastclone_runner_spec.rb
@@ -85,17 +85,50 @@ describe GitFastClone::Runner do
   end
 
   describe '.clone' do
-    it 'should clone correctly' do
-      terrapin_commandline_double = double('new_terrapin_commandline')
-      allow(subject).to receive(:with_git_mirror) {}
+    let(:terrapin_commandline_double) { double('new_terrapin_commandline') }
+    before(:each) do
       allow(terrapin_commandline_double).to receive(:run) {}
-      allow(Terrapin::CommandLine).to receive(:new) { terrapin_commandline_double }
-
       expect(Time).to receive(:now).twice { 0 }
-      expect(Terrapin::CommandLine).to receive(:new)
-      expect(terrapin_commandline_double).to receive(:run)
+      allow(Dir).to receive(:pwd) { '/pwd' }
+      allow(Dir).to receive(:chdir).and_yield
+      allow(subject).to receive(:with_git_mirror).and_yield('/cache')
+    end
+
+    it 'should clone correctly' do
+      expect(Terrapin::CommandLine).to receive(:new).with(
+        'git clone',
+        '--quiet --reference :mirror :url :path'
+      ) { terrapin_commandline_double }
+      expect(Terrapin::CommandLine).to receive(:new).with(
+        'git checkout',
+        '--quiet :rev'
+      ) { terrapin_commandline_double }
+      expect(terrapin_commandline_double).to receive(:run).with({
+                                                                  mirror: '/cache',
+                                                                  url: placeholder_arg,
+                                                                  path: '/pwd/.',
+                                                                  config: ''
+                                                                })
+      expect(terrapin_commandline_double).to receive(:run).with({ rev: placeholder_arg })
 
       subject.clone(placeholder_arg, placeholder_arg, '.', nil)
+    end
+
+    describe 'with custom configs' do
+      it 'should clone correctly' do
+        expect(Terrapin::CommandLine).to receive(:new).with(
+          'git clone',
+          '--quiet --reference :mirror :url :path --config :config'
+        ) { terrapin_commandline_double }
+        expect(terrapin_commandline_double).to receive(:run).with({
+                                                                    mirror: '/cache',
+                                                                    url: placeholder_arg,
+                                                                    path: '/pwd/.',
+                                                                    config: 'config'
+                                                                  })
+
+        subject.clone(placeholder_arg, nil, '.', 'config')
+      end
     end
   end
 


### PR DESCRIPTION
Adds an extra parameter to git-fastclone that allows adding git's `--config {param}` to the `clone` command.
This command could be helpful if we want to customize the repo, e.g. auto-fetching extra reference patters (by default only `refs/heads/*` is fetched) with `remote.origin.fetch`. 

### How to test

#### Pass extra fetch origin as a custom config

1. Command
```
$ git-fastclone  git@github.com:team/repo.git -v 'location'  --config "remote.origin.fetch=+refs/custom/*:refs/remotes/origin/custom/*"
$ cd location
```
2. Check if the cloned repo has applied configs:
```
$ git --no-pager config  --get-all remote.origin.fetch 
+refs/custom/*:refs/remotes/origin/custom/*
+refs/heads/*:refs/remotes/origin/*
```
3. Check if `refs/custom/*` references are available:
```
git show-ref | grep custom
```


#### No configs

1. Command
```
$ git-fastclone  git@github.com:team/repo.git -v 'location' 
```
2. Check if the cloned repo has applied configs:
```
$ git --no-pager config  --get-all remote.origin.fetch 
+refs/heads/*:refs/remotes/origin/*
```