### PR TITLE
Make sure to repopulate the reference repo after it is cleared

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git-fastclone (1.3.1)
+    git-fastclone (1.3.2)
       colorize
       terrapin (~> 0.6.0)
 

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -379,8 +379,9 @@ module GitFastClone
     # To avoid corruption of the cache, if we failed to update or check out we remove
     # the cache directory entirely. This may cause the current clone to fail, but if the
     # underlying error from git is transient it will not affect future clones.
-    def clear_cache(dir)
+    def clear_cache(dir, url)
       FileUtils.remove_entry_secure(dir, force: true)
+      reference_updated.delete(reference_repo_name(url))
     end
 
     # This command will create and bring the mirror up-to-date on-demand,
@@ -407,7 +408,7 @@ module GitFastClone
         rescue Terrapin::ExitStatusError => e
           if retriable_error?(e)
             print_formatted_error(e)
-            clear_cache(dir)
+            clear_cache(dir, url)
 
             if attempt_number < retries_allowed
               update_reference_repo(url, true)

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -410,6 +410,7 @@ module GitFastClone
             clear_cache(dir)
 
             if attempt_number < retries_allowed
+              update_reference_repo(url, true)
               attempt_number += 1
               retry
             end

--- a/lib/git-fastclone/version.rb
+++ b/lib/git-fastclone/version.rb
@@ -2,5 +2,5 @@
 
 # Version string for git-fastclone
 module GitFastCloneVersion
-  VERSION = '1.3.1'
+  VERSION = '1.3.2'
 end

--- a/spec/git_fastclone_runner_spec.rb
+++ b/spec/git_fastclone_runner_spec.rb
@@ -371,23 +371,27 @@ describe GitFastClone::Runner do
     end
 
     it 'should yield properly' do
+      expect(subject).to receive(:update_reference_repo).once {}
       expect(subject).not_to receive(:clear_cache)
       try_with_git_mirror([true], [[test_reference_repo_dir, 0]])
     end
 
-    it 'should retry once for retriable errors' do
+    it 'should retry once for retriable errors, clearing and repopulating the cache' do
       expect(subject).to receive(:clear_cache).once {}
+      expect(subject).to receive(:update_reference_repo).twice {}
       try_with_git_mirror([retriable_error, true], [[test_reference_repo_dir, 1]])
     end
 
     it 'should only retry twice at most' do
       expect(subject).to receive(:clear_cache).twice {}
+      expect(subject).to receive(:update_reference_repo).twice {}
       expect do
         try_with_git_mirror([retriable_error, retriable_error], [])
       end.to raise_error(Terrapin::ExitStatusError)
     end
 
     it 'should not retry for non-retriable errors' do
+      expect(subject).to receive(:update_reference_repo).once {}
       expect(subject).not_to receive(:clear_cache)
       expect do
         try_with_git_mirror(['Some unexpected error message'], [])


### PR DESCRIPTION
When the fastclone cache is cleared, we don't repopulate it before trying to use it as a mirror. This fixes that bug.