### PR TITLE
Replace Terrapin with BuildExecution to fix process deadlock when output to stderr is fills buffer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,8 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   TargetRubyVersion: 2.7
   NewCops: enable
+  Exclude:
+    - 'lib/runner_execution.rb'
 
 Naming/FileName:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,8 +3,6 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   TargetRubyVersion: 2.7
   NewCops: enable
-  Exclude:
-    - 'lib/runner_execution.rb'
 
 Naming/FileName:
   Exclude:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git-fastclone (1.3.3)
+    git-fastclone (1.3.4)
       colorize
       terrapin (~> 0.6.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,13 +3,11 @@ PATH
   specs:
     git-fastclone (1.4.0)
       colorize
-      terrapin (~> 0.6.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    climate_control (0.2.0)
     colorize (0.8.1)
     diff-lcs (1.5.0)
     json (2.6.3)
@@ -46,8 +44,6 @@ GEM
     rubocop-ast (1.24.0)
       parser (>= 3.1.1.0)
     ruby-progressbar (1.11.0)
-    terrapin (0.6.0)
-      climate_control (>= 0.0.3, < 1.0)
     unicode-display_width (2.3.0)
 
 PLATFORMS
@@ -61,4 +57,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.3.26
+   2.3.21

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,4 +57,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.3.21
+   2.3.26

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git-fastclone (1.3.4)
+    git-fastclone (1.4.0)
       colorize
       terrapin (~> 0.6.0)
 

--- a/git-fastclone.gemspec
+++ b/git-fastclone.gemspec
@@ -37,6 +37,5 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.7'
 
   gem.add_runtime_dependency 'colorize'
-  gem.add_runtime_dependency 'terrapin', '~> 0.6.0'
   gem.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -345,11 +345,11 @@ module GitFastClone
     # that this repo has been updated on this run of fastclone
     def store_updated_repo(url, mirror, repo_name, fail_hard)
       unless Dir.exist?(mirror)
-        Terrapin::CommandLine.new('git clone', '--mirror :url :mirror' + NO_STDOUT_ERR)
+        Terrapin::CommandLine.new('git clone', "--mirror :url :mirror#{NO_STDOUT_ERR}")
                              .run(url: url.to_s, mirror: mirror.to_s)
       end
 
-      Terrapin::CommandLine.new('cd', ':path; git remote update --prune' + NO_STDOUT_ERR).run(path: mirror)
+      Terrapin::CommandLine.new('cd', ":path; git remote update --prune#{NO_STDOUT_ERR}").run(path: mirror)
 
       reference_updated[repo_name] = true
     rescue Terrapin::ExitStatusError => e

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -358,7 +358,6 @@ module GitFastClone
       # To avoid corruption of the cache, if we failed to update or check out we remove
       # the cache directory entirely. This may cause the current clone to fail, but if the
       # underlying error from git is transient it will not affect future clones.
-      puts 'elton checkpoint1'
       clear_cache(mirror, url)
       raise e if fail_hard
     end
@@ -376,7 +375,7 @@ module GitFastClone
       error.to_s =~ /^STDERR:\n.*^#{Regexp.union(error_strings)}/m
     end
 
-    def print_formatted_error(error, _location)
+    def print_formatted_error(error)
       indented_error = error.to_s.split("\n").map { |s| ">  #{s}\n" }.join
       puts "[INFO] Encountered a retriable error:\n#{indented_error}\n"
     end
@@ -413,7 +412,7 @@ module GitFastClone
       end
     rescue RunnerExecutionRuntimeError => e
       if retriable_error?(e.output)
-        print_formatted_error(e.output, dir)
+        print_formatted_error(e.output)
         clear_cache(dir, url)
 
         if attempt_number < retries_allowed

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -73,8 +73,6 @@ module GitFastClone
 
     DEFAULT_GIT_ALLOW_PROTOCOL = 'file:git:http:https:ssh'
 
-    NO_STDOUT_ERR = ' > /dev/null 2>&1 '
-
     attr_accessor :reference_dir, :prefetch_submodules, :reference_updated, :reference_mutex,
                   :options, :abs_clone_path, :using_local_repo, :verbose, :color,
                   :flock_timeout_secs

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -356,7 +356,7 @@ module GitFastClone
       # To avoid corruption of the cache, if we failed to update or check out we remove
       # the cache directory entirely. This may cause the current clone to fail, but if the
       # underlying error from git is transient it will not affect future clones.
-      puts "Removing the fastclone cache."
+      puts '[WARN] Removing the fastclone cache.'
       FileUtils.remove_entry_secure(mirror, force: true)
       raise e if fail_hard
     end

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -364,15 +364,15 @@ module GitFastClone
 
     def retriable_error?(error)
       error_strings = [
-        'fatal: missing blob object',
-        'fatal: remote did not send all necessary objects',
-        /fatal: packed object [a-z0-9]+ \(stored in .*?\) is corrupt/,
-        /fatal: pack has \d+ unresolved delta/,
-        'error: unable to read sha1 file of ',
-        'fatal: did not receive expected object',
+        /^fatal: missing blob object/,
+        /^fatal: remote did not send all necessary objects/,
+        /^fatal: packed object [a-z0-9]+ \(stored in .*?\) is corrupt/,
+        /^fatal: pack has \d+ unresolved delta/,
+        /^error: unable to read sha1 file of /,
+        /^fatal: did not receive expected object/,
         /^fatal: unable to read tree [a-z0-9]+\n^warning: Clone succeeded, but checkout failed/
       ]
-      error.to_s =~ /^STDERR:\n.*^#{Regexp.union(error_strings)}/m
+      error.to_s =~ /.*#{Regexp.union(error_strings)}/m
     end
 
     def print_formatted_error(error)

--- a/lib/git-fastclone/version.rb
+++ b/lib/git-fastclone/version.rb
@@ -2,5 +2,5 @@
 
 # Version string for git-fastclone
 module GitFastCloneVersion
-  VERSION = '1.3.4'
+  VERSION = '1.4.0'
 end

--- a/lib/git-fastclone/version.rb
+++ b/lib/git-fastclone/version.rb
@@ -2,5 +2,5 @@
 
 # Version string for git-fastclone
 module GitFastCloneVersion
-  VERSION = '1.3.3'
+  VERSION = '1.3.4'
 end

--- a/lib/runner_execution.rb
+++ b/lib/runner_execution.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# rubocop:disable all
 
 require 'open3'
 require 'logger'
@@ -217,3 +218,4 @@ module RunnerExecution
   end
   module_function :logger
 end
+# rubocop:enable all

--- a/lib/runner_execution.rb
+++ b/lib/runner_execution.rb
@@ -1,0 +1,217 @@
+require 'open3'
+require 'logger'
+
+# Execution primitives that force explicit error handling and never call the shell.
+# Cargo-culted from internal BuildExecution code on top of public version: https://github.com/square/build_execution
+module RunnerExecution
+  class RunnerExecutionRuntimeError < RuntimeError
+    attr_reader :status, :exitstatus, :command, :output
+
+    def initialize(status, command, output = nil)
+      @status           = status
+      @exitstatus       = status.exitstatus
+      @command          = command
+      @output           = output
+
+      super "#{status.inspect}\n#{command.inspect}"
+    end
+  end
+
+  # Wrapper around open3.pipeline_r which fails on error.
+  # and stops users from invoking the shell by accident.
+  def fail_pipe_on_error(*cmd_list, quiet: false, **opts)
+    print_command('Running Pipeline:', cmd_list) unless quiet
+
+    env = opts.delete(:env) { {} }
+    raise ArgumentError, "The :env option must be a hash, not #{env.inspect}" if !env.is_a?(Hash)
+
+    cmd_list.map! { |cmd| shell_safe(cmd).unshift(env) }
+
+    output, *status_list = Open3.pipeline_r(*cmd_list, opts) do |out, wait_threads|
+      out_reader = Thread.new do
+        if quiet
+          output = out.read
+        else
+          # Output from pipeline should go to stdout and also get returned for
+          # processing if necessary.
+          output = tee(out, STDOUT)
+        end
+        out.close
+        output
+      end
+      [out_reader.value] + wait_threads.map(&:value)
+    end
+    exit_on_status(output, cmd_list, status_list, quiet: quiet)
+  end
+  module_function :fail_pipe_on_error
+
+  # Runs a command that fails on error.
+  # Uses popen2e wrapper. Handles bad statuses with potential for retries.
+  def fail_on_error(*cmd, stdin_data: nil, binmode: false, quiet: false, **opts)
+    print_command('Running Shell Safe Command:', [cmd]) unless quiet
+    shell_safe_cmd = shell_safe(cmd)
+    retry_times = opts[:retry] || 0
+    opts.delete(:retry)
+
+    while retry_times >= 0
+      output, status = popen2e_wrapper(*shell_safe_cmd, stdin_data: stdin_data, binmode: binmode,
+                                       quiet: quiet, **opts)
+
+      break unless status.exitstatus != 0
+
+      logger.debug("Command failed with exit status #{status.exitstatus}, retrying #{retry_times} more time(s).") if retry_times > 0
+      retry_times -= 1
+    end
+
+    # Get out with the status, good or bad.
+    exit_on_status(output, [shell_safe_cmd], [status], quiet: quiet)
+  end
+  module_function :fail_on_error
+
+  # Wrapper around open3.popen2e
+  #
+  # We emulate open3.capture2e with the following changes in behavior:
+  # 1) The command is printed to stdout before execution.
+  # 2) Attempts to use the shell implicitly are blocked.
+  # 3) Nonzero return codes result in the process exiting.
+  # 4) Combined stdout/stderr goes to callers stdout
+  #    (continuously streamed) and is returned as a string
+  #
+  # If you're looking for more process/stream control read the spawn
+  # documentation, and pass options directly here
+  def popen2e_wrapper(*shell_safe_cmd, stdin_data: nil, binmode: false,
+                       quiet: false, **opts)
+
+    env = opts.delete(:env) { {} }
+    raise ArgumentError, "The :env option must be a hash, not #{env.inspect}" if !env.is_a?(Hash)
+
+    # Most of this is copied from Open3.capture2e in ruby/lib/open3.rb
+    _output, _status = Open3.popen2e(env, *shell_safe_cmd, opts) do |i, oe, t|
+      if binmode
+        i.binmode
+        oe.binmode
+      end
+
+      outerr_reader = Thread.new do
+        if quiet
+          oe.read
+        else
+          # Instead of oe.read, we redirect. Output from command goes to stdout
+          # and also is returned for processing if necessary.
+          tee(oe, STDOUT)
+        end
+      end
+
+      if stdin_data
+        begin
+          i.write stdin_data
+        rescue Errno::EPIPE
+        end
+      end
+
+      i.close
+      [outerr_reader.value, t.value]
+    end
+  end
+  module_function :popen2e_wrapper
+
+  # Look at a cmd list intended for spawn.
+  # determine if spawn will call the shell implicitly, fail in that case.
+  def shell_safe(cmd)
+    # Take the first string and change it to a list of [executable,argv0]
+    # This syntax for calling popen2e (and eventually spawn) avoids
+    # the shell in all cases
+    shell_safe_cmd = Array.new(cmd)
+    if shell_safe_cmd[0].class == String
+      shell_safe_cmd[0] = [shell_safe_cmd[0], shell_safe_cmd[0]]
+    end
+    shell_safe_cmd
+  end
+  module_function :shell_safe
+
+  def debug_print_cmd_list(cmd_list)
+    # Take a list of command argument lists like you'd sent to open3.pipeline or
+    # fail_on_error_pipe and print out a string that would do the same thing when
+    # entered at the shell.
+    #
+    # This is a converter from our internal representation of commands to a subset
+    # of bash that can be executed directly.
+    #
+    # Note this has problems if you specify env or opts
+    # TODO: make this remove those command parts
+    "\"" +
+      cmd_list.map do |cmd|
+        cmd.map do |arg|
+          arg.gsub("\"", "\\\"") # Escape all double quotes in command arguments
+        end.join("\" \"") # Fully quote all command parts, beginning and end.
+      end.join("\" | \"") + "\"" # Pipe commands to one another.
+  end
+  module_function :debug_print_cmd_list
+
+  # Prints a formatted string with command
+  def print_command(message, cmd)
+    logger.debug("#{message} #{debug_print_cmd_list(cmd)}\n")
+  end
+  module_function :print_command
+
+  # Takes in an input stream and an output stream
+  # Redirects data from one to the other until the input stream closes.
+  # Returns all data that passed through on return.
+  def tee(in_stream, out_stream)
+    alldata = ''
+    loop do
+      begin
+        data = in_stream.read_nonblock(4096)
+        alldata += data
+        out_stream.write(data)
+        out_stream.flush
+      rescue IO::WaitReadable
+        IO.select([in_stream])
+        retry
+      rescue IOError
+        break
+      end
+    end
+    alldata
+  end
+  module_function :tee
+
+  # If any of the statuses are bad, exits with the
+  # return code of the first one.
+  #
+  # Otherwise returns first argument (output)
+  def exit_on_status(output, cmd_list, status_list, quiet: false)
+    status_list.each_index do |index|
+      status = status_list[index]
+      cmd = cmd_list[index]
+      check_status(cmd, status, output: output, quiet: quiet)
+    end
+
+    output
+  end
+  module_function :exit_on_status
+
+  def check_status(cmd, status, output: nil, quiet: false)
+    return if status.exited? && status.exitstatus == 0
+
+    # If we exited nonzero or abnormally, print debugging info and explode.
+    if status.exited?
+      logger.debug("Process Exited normally. Exit status:#{status.exitstatus}") unless quiet
+    else
+      # This should only get executed if we're stopped or signaled
+      logger.debug("Process exited abnormally:\nProcessStatus: #{status.inspect}\n" \
+        "Raw POSIX Status: #{status.to_i}\n") unless quiet
+    end
+
+    raise RunnerExecutionRuntimeError.new(status, cmd, output)
+  end
+  module_function :check_status
+
+  DEFAULT_LOGGER = Logger.new(STDOUT)
+  private_constant :DEFAULT_LOGGER
+
+  def logger
+    DEFAULT_LOGGER
+  end
+  module_function :logger
+end

--- a/lib/runner_execution.rb
+++ b/lib/runner_execution.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'open3'
 require 'logger'
 
@@ -23,7 +25,7 @@ module RunnerExecution
     print_command('Running Pipeline:', cmd_list) unless quiet
 
     env = opts.delete(:env) { {} }
-    raise ArgumentError, "The :env option must be a hash, not #{env.inspect}" if !env.is_a?(Hash)
+    raise ArgumentError, "The :env option must be a hash, not #{env.inspect}" unless env.is_a?(Hash)
 
     cmd_list.map! { |cmd| shell_safe(cmd).unshift(env) }
 

--- a/spec/git_fastclone_runner_spec.rb
+++ b/spec/git_fastclone_runner_spec.rb
@@ -391,8 +391,8 @@ describe GitFastClone::Runner do
 
     def clone_cmds
       [
-        ['git clone', '--mirror :url :mirror'],
-        ['cd', ':path; git remote update --prune']
+        ['git clone', '--mirror :url :mirror > /dev/null 2>&1 '],
+        ['cd', ':path; git remote update --prune > /dev/null 2>&1 ']
       ]
     end
 

--- a/spec/git_fastclone_runner_spec.rb
+++ b/spec/git_fastclone_runner_spec.rb
@@ -319,10 +319,6 @@ describe GitFastClone::Runner do
   describe '.with_git_mirror' do
     def retriable_error
       %(
-        STDOUT:
-
-        STDERR:
-
         fatal: bad object ee35b1e14e7c3a53dcc14d82606e5b872f6a05a7
         fatal: remote did not send all necessary objects
       ).strip.split("\n").map(&:strip).join("\n")
@@ -423,7 +419,7 @@ describe GitFastClone::Runner do
 
   describe '.retriable_error?' do
     def format_error(error)
-      error_wrapper = "STDOUT:\n\nSTDERR:\n#{error}"
+      error_wrapper = "#{error}"
       error_wrapper.strip.lines.map(&:strip).join("\n")
     end
 

--- a/spec/git_fastclone_runner_spec.rb
+++ b/spec/git_fastclone_runner_spec.rb
@@ -97,12 +97,12 @@ describe GitFastClone::Runner do
 
     it 'should clone correctly' do
       expect(subject).to receive(:fail_pipe_on_error).with(
-        ["git", "checkout", "--quiet", "PH"],
-        {:quiet=>true}
+        ['git', 'checkout', '--quiet', 'PH'],
+        { quiet: true }
       ) { runner_execution_double }
       expect(subject).to receive(:fail_pipe_on_error).with(
-        ["git", "clone", "--quiet", "--reference", "/cache", "PH", "/pwd/."],
-        {:quiet=>true}
+        ['git', 'clone', '--quiet', '--reference', '/cache', 'PH', '/pwd/.'],
+        { quiet: true }
       ) { runner_execution_double }
 
       subject.clone(placeholder_arg, placeholder_arg, '.', nil)
@@ -110,8 +110,8 @@ describe GitFastClone::Runner do
 
     it 'should clone correctly with custom configs' do
       expect(subject).to receive(:fail_pipe_on_error).with(
-        ["git", "clone", "--quiet", "--reference", "/cache", "PH", "/pwd/.", "--config", "config"],
-        {:quiet=>true}
+        ['git', 'clone', '--quiet', '--reference', '/cache', 'PH', '/pwd/.', '--config', 'config'],
+        { quiet: true }
       ) { runner_execution_double }
 
       subject.clone(placeholder_arg, nil, '.', 'config')
@@ -285,9 +285,9 @@ describe GitFastClone::Runner do
         ex = RunnerExecution::RunnerExecutionRuntimeError.new(status, 'cmd')
         allow(subject).to receive(:fail_pipe_on_error) { raise ex }
         expect(FileUtils).to receive(:remove_entry_secure).with(placeholder_arg, force: true)
-        expect {
+        expect do
           subject.store_updated_repo(placeholder_arg, placeholder_arg, placeholder_arg, true)
-        }.to raise_error(ex)
+        end.to raise_error(ex)
       end
     end
 
@@ -298,9 +298,9 @@ describe GitFastClone::Runner do
         ex = RunnerExecution::RunnerExecutionRuntimeError.new(status, 'cmd')
         allow(subject).to receive(:fail_pipe_on_error) { raise ex }
         expect(FileUtils).to receive(:remove_entry_secure).with(placeholder_arg, force: true)
-        expect {
+        expect do
           subject.store_updated_repo(placeholder_arg, placeholder_arg, placeholder_arg, false)
-        }.to_not raise_error(ex)
+        end.to_not raise_error(ex)
       end
     end
 
@@ -335,7 +335,7 @@ describe GitFastClone::Runner do
           ->(url) { url }
         else
           # Simulate failed error response
-          ->(_url) {
+          lambda { |_url|
             status = double('status')
             allow(status).to receive(:exitstatus).and_return(1)
             raise RunnerExecution::RunnerExecutionRuntimeError.new(status, 'cmd', response)
@@ -364,7 +364,7 @@ describe GitFastClone::Runner do
       }
       allow(subject).to receive(:fail_on_error) { |*params|
         # last one is an argument `quiet:`
-        command = params.first(params.size-1)
+        command = params.first(params.size - 1)
         expect(expected_commands.length).to be > 0
         expected_command = expected_commands.shift
         expect(command).to eq(expected_command)

--- a/spec/git_fastclone_runner_spec.rb
+++ b/spec/git_fastclone_runner_spec.rb
@@ -36,7 +36,7 @@ describe GitFastClone::Runner do
 
   before do
     stub_const('ARGV', ['ssh://git@git.com/git-fastclone.git', 'test_reference_dir'])
-    allow(STDOUT).to receive(:puts)
+    allow($stdout).to receive(:puts)
   end
 
   let(:yielded) { [] }
@@ -393,7 +393,8 @@ describe GitFastClone::Runner do
 
     def clone_cmds(verbose: false)
       [
-        ['git', 'clone', verbose ? '--verbose' : '--quiet', '--mirror', test_url_valid, test_reference_repo_dir],
+        ['git', 'clone', verbose ? '--verbose' : '--quiet', '--mirror', test_url_valid,
+         test_reference_repo_dir],
         ['git', 'remote', verbose ? '--verbose' : nil, 'update', '--prune'].compact
       ]
     end
@@ -401,7 +402,7 @@ describe GitFastClone::Runner do
     context 'expecting 1 clone attempt' do
       context 'with verbose mode on' do
         before { subject.verbose = true }
-        let(:expected_commands) { clone_cmds(verbose:true) }
+        let(:expected_commands) { clone_cmds(verbose: true) }
 
         it 'should succeed with a successful clone' do
           expect(subject).not_to receive(:clear_cache)
@@ -453,7 +454,7 @@ describe GitFastClone::Runner do
 
   describe '.retriable_error?' do
     def format_error(error)
-      error_wrapper = "#{error}"
+      error_wrapper = error.to_s
       error_wrapper.strip.lines.map(&:strip).join("\n")
     end
 


### PR DESCRIPTION
### Why this change
In our CI cluster, we run into fastclone got stuck because of this bug: https://github.com/thoughtbot/terrapin/pull/5
We verified that after this change it run smoothly after consistently reproducing it.
Our codebase is so big that even `git remote update --prune` returns a huge output causing this problem to manifest
When we interrupt the stuck process, we also see it stuck at the read stream function as indicated by above PR
Also verbose mode does not redirect output from git operations inside Terrapin to stdout for some reason. Therefore we think this is a good fix.

Also add log when cleaning cache because when lots of CI machiens got cache cleaned, we will throttle the network by trying to populate the cache at the same time. So adding log to warn about this.

- [x] Fix spec, should have spec failing or need to add some
- [x] Update version file and Gemfile.lock