### PR TITLE
Stops using fail_pipe_on_error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git-fastclone (1.4.0)
+    git-fastclone (1.4.1)
       colorize
 
 GEM

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -212,13 +212,13 @@ module GitFastClone
         clone_commands = ['git', 'clone', verbose ? '--verbose' : '--quiet']
         clone_commands << '--reference' << mirror.to_s << url.to_s << clone_dest
         clone_commands << '--config' << config.to_s unless config.nil?
-        fail_pipe_on_error(clone_commands, quiet: !verbose)
+        fail_on_error(*clone_commands, quiet: !verbose)
       end
 
       # Only checkout if we're changing branches to a non-default branch
       if rev
         Dir.chdir(File.join(abs_clone_path, src_dir)) do
-          fail_pipe_on_error(['git', 'checkout', '--quiet', rev.to_s], quiet: !verbose)
+          fail_on_error('git', 'checkout', '--quiet', rev.to_s, quiet: !verbose)
         end
       end
 
@@ -261,10 +261,9 @@ module GitFastClone
       threads << Thread.new do
         with_git_mirror(submodule_url) do |mirror, _|
           Dir.chdir(File.join(abs_clone_path, pwd).to_s) do
-            fail_pipe_on_error(
-              ['git', 'submodule', verbose ? nil : '--quiet', 'update', '--reference', mirror.to_s,
-               submodule_path.to_s].compact, quiet: !verbose
-            )
+            cmd = ['git', 'submodule', verbose ? nil : '--quiet', 'update', '--reference', mirror.to_s,
+                   submodule_path.to_s].compact
+            fail_on_error(*cmd, quiet: !verbose)
           end
         end
 
@@ -337,21 +336,13 @@ module GitFastClone
     # that this repo has been updated on this run of fastclone
     def store_updated_repo(url, mirror, repo_name, fail_hard)
       unless Dir.exist?(mirror)
-        fail_pipe_on_error(
-          ['git', 'clone', verbose ? '--verbose' : '--quiet', '--mirror', url.to_s,
-           mirror.to_s], quiet: !verbose
-        )
+        fail_on_error('git', 'clone', verbose ? '--verbose' : '--quiet', '--mirror', url.to_s, mirror.to_s,
+                      quiet: !verbose)
       end
 
       Dir.chdir(mirror) do
         cmd = ['git', 'remote', verbose ? '--verbose' : nil, 'update', '--prune'].compact
-        if verbose
-          fail_pipe_on_error(cmd, quiet: !verbose)
-        else
-          # Because above operation might spit out a lot to stderr, we use this to swallow them
-          # and only display if the operation return non 0 exit code
-          fail_on_error(*cmd, quiet: !verbose)
-        end
+        fail_on_error(*cmd, quiet: !verbose)
       end
       reference_updated[repo_name] = true
     rescue RunnerExecutionRuntimeError => e

--- a/lib/git-fastclone/version.rb
+++ b/lib/git-fastclone/version.rb
@@ -2,5 +2,5 @@
 
 # Version string for git-fastclone
 module GitFastCloneVersion
-  VERSION = '1.4.0'
+  VERSION = '1.4.1'
 end

--- a/spec/git_fastclone_runner_spec.rb
+++ b/spec/git_fastclone_runner_spec.rb
@@ -89,7 +89,7 @@ describe GitFastClone::Runner do
   describe '.clone' do
     let(:runner_execution_double) { double('runner_execution') }
     before(:each) do
-      allow(runner_execution_double).to receive(:fail_pipe_on_error) {}
+      allow(runner_execution_double).to receive(:fail_on_error) {}
       allow(Dir).to receive(:pwd) { '/pwd' }
       allow(Dir).to receive(:chdir).and_yield
       allow(subject).to receive(:with_git_mirror).and_yield('/cache', 0)
@@ -97,12 +97,12 @@ describe GitFastClone::Runner do
     end
 
     it 'should clone correctly' do
-      expect(subject).to receive(:fail_pipe_on_error).with(
-        ['git', 'checkout', '--quiet', 'PH'],
+      expect(subject).to receive(:fail_on_error).with(
+        'git', 'checkout', '--quiet', 'PH',
         { quiet: true }
       ) { runner_execution_double }
-      expect(subject).to receive(:fail_pipe_on_error).with(
-        ['git', 'clone', '--quiet', '--reference', '/cache', 'PH', '/pwd/.'],
+      expect(subject).to receive(:fail_on_error).with(
+        'git', 'clone', '--quiet', '--reference', '/cache', 'PH', '/pwd/.',
         { quiet: true }
       ) { runner_execution_double }
 
@@ -111,12 +111,12 @@ describe GitFastClone::Runner do
 
     it 'should clone correctly with verbose mode on' do
       subject.verbose = true
-      expect(subject).to receive(:fail_pipe_on_error).with(
-        ['git', 'checkout', '--quiet', 'PH'],
+      expect(subject).to receive(:fail_on_error).with(
+        'git', 'checkout', '--quiet', 'PH',
         { quiet: false }
       ) { runner_execution_double }
-      expect(subject).to receive(:fail_pipe_on_error).with(
-        ['git', 'clone', '--verbose', '--reference', '/cache', 'PH', '/pwd/.'],
+      expect(subject).to receive(:fail_on_error).with(
+        'git', 'clone', '--verbose', '--reference', '/cache', 'PH', '/pwd/.',
         { quiet: false }
       ) { runner_execution_double }
 
@@ -124,8 +124,8 @@ describe GitFastClone::Runner do
     end
 
     it 'should clone correctly with custom configs' do
-      expect(subject).to receive(:fail_pipe_on_error).with(
-        ['git', 'clone', '--quiet', '--reference', '/cache', 'PH', '/pwd/.', '--config', 'config'],
+      expect(subject).to receive(:fail_on_error).with(
+        'git', 'clone', '--quiet', '--reference', '/cache', 'PH', '/pwd/.', '--config', 'config',
         { quiet: true }
       ) { runner_execution_double }
 
@@ -298,7 +298,7 @@ describe GitFastClone::Runner do
         status = double('status')
         allow(status).to receive(:exitstatus).and_return(1)
         ex = RunnerExecution::RunnerExecutionRuntimeError.new(status, 'cmd')
-        allow(subject).to receive(:fail_pipe_on_error) { raise ex }
+        allow(subject).to receive(:fail_on_error) { raise ex }
         expect(FileUtils).to receive(:remove_entry_secure).with(placeholder_arg, force: true)
         expect do
           subject.store_updated_repo(placeholder_arg, placeholder_arg, placeholder_arg, true)
@@ -311,7 +311,7 @@ describe GitFastClone::Runner do
         status = double('status')
         allow(status).to receive(:exitstatus).and_return(1)
         ex = RunnerExecution::RunnerExecutionRuntimeError.new(status, 'cmd')
-        allow(subject).to receive(:fail_pipe_on_error) { raise ex }
+        allow(subject).to receive(:fail_on_error) { raise ex }
         expect(FileUtils).to receive(:remove_entry_secure).with(placeholder_arg, force: true)
         expect do
           subject.store_updated_repo(placeholder_arg, placeholder_arg, placeholder_arg, false)
@@ -322,7 +322,7 @@ describe GitFastClone::Runner do
     let(:placeholder_hash) { {} }
 
     it 'should correctly update the hash' do
-      allow(subject).to receive(:fail_pipe_on_error)
+      allow(subject).to receive(:fail_on_error)
       allow(Dir).to receive(:chdir) {}
 
       subject.reference_updated = placeholder_hash
@@ -367,12 +367,6 @@ describe GitFastClone::Runner do
     let(:expected_commands) { [] }
 
     before(:each) do
-      allow(subject).to receive(:fail_pipe_on_error) { |*params|
-        command = params[0]
-        expect(expected_commands.length).to be > 0
-        expected_command = expected_commands.shift
-        expect(command).to eq(expected_command)
-      }
       allow(subject).to receive(:fail_on_error) { |*params|
         # last one is an argument `quiet:`
         command = params.first(params.size - 1)


### PR DESCRIPTION
Its output doesn't capture stderr. Thus, all retriable errors become fatal errors. Instead, we will use fail_on_error which also captures stderr.