### PR TITLE
Add a mode to print git errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git-fastclone (1.4.1)
+    git-fastclone (1.4.2)
       colorize
 
 GEM

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -74,7 +74,7 @@ module GitFastClone
     DEFAULT_GIT_ALLOW_PROTOCOL = 'file:git:http:https:ssh'
 
     attr_accessor :reference_dir, :prefetch_submodules, :reference_updated, :reference_mutex,
-                  :options, :abs_clone_path, :using_local_repo, :verbose, :color,
+                  :options, :abs_clone_path, :using_local_repo, :verbose, :print_git_errors, :color,
                   :flock_timeout_secs
 
     def initialize
@@ -99,6 +99,8 @@ module GitFastClone
       self.using_local_repo = false
 
       self.verbose = false
+
+      self.print_git_errors = false
 
       self.color = false
 
@@ -133,7 +135,13 @@ module GitFastClone
         end
 
         opts.on('-v', '--verbose', 'Verbose mode') do
+          puts '--print_git_errors is redundant when using --verbose' if print_git_errors
           self.verbose = true
+        end
+
+        opts.on('--print_git_errors', 'Print git output if a command fails') do
+          puts '--print_git_errors is redundant when using --verbose' if verbose
+          self.print_git_errors = true
         end
 
         opts.on('-c', '--color', 'Display colored output') do
@@ -212,13 +220,14 @@ module GitFastClone
         clone_commands = ['git', 'clone', verbose ? '--verbose' : '--quiet']
         clone_commands << '--reference' << mirror.to_s << url.to_s << clone_dest
         clone_commands << '--config' << config.to_s unless config.nil?
-        fail_on_error(*clone_commands, quiet: !verbose)
+        fail_on_error(*clone_commands, quiet: !verbose, print_on_failure: print_git_errors)
       end
 
       # Only checkout if we're changing branches to a non-default branch
       if rev
         Dir.chdir(File.join(abs_clone_path, src_dir)) do
-          fail_on_error('git', 'checkout', '--quiet', rev.to_s, quiet: !verbose)
+          fail_on_error('git', 'checkout', '--quiet', rev.to_s, quiet: !verbose,
+                                                                print_on_failure: print_git_errors)
         end
       end
 
@@ -243,7 +252,8 @@ module GitFastClone
       submodule_url_list = []
       output = ''
       Dir.chdir(File.join(abs_clone_path, pwd).to_s) do
-        output = fail_on_error('git', 'submodule', 'init', quiet: !verbose)
+        output = fail_on_error('git', 'submodule', 'init', quiet: !verbose,
+                                                           print_on_failure: print_git_errors)
       end
 
       output.split("\n").each do |line|
@@ -263,7 +273,7 @@ module GitFastClone
           Dir.chdir(File.join(abs_clone_path, pwd).to_s) do
             cmd = ['git', 'submodule', verbose ? nil : '--quiet', 'update', '--reference', mirror.to_s,
                    submodule_path.to_s].compact
-            fail_on_error(*cmd, quiet: !verbose)
+            fail_on_error(*cmd, quiet: !verbose, print_on_failure: print_git_errors)
           end
         end
 
@@ -337,12 +347,12 @@ module GitFastClone
     def store_updated_repo(url, mirror, repo_name, fail_hard)
       unless Dir.exist?(mirror)
         fail_on_error('git', 'clone', verbose ? '--verbose' : '--quiet', '--mirror', url.to_s, mirror.to_s,
-                      quiet: !verbose)
+                      quiet: !verbose, print_on_failure: print_git_errors)
       end
 
       Dir.chdir(mirror) do
         cmd = ['git', 'remote', verbose ? '--verbose' : nil, 'update', '--prune'].compact
-        fail_on_error(*cmd, quiet: !verbose)
+        fail_on_error(*cmd, quiet: !verbose, print_on_failure: print_git_errors)
       end
       reference_updated[repo_name] = true
     rescue RunnerExecutionRuntimeError => e

--- a/lib/git-fastclone/version.rb
+++ b/lib/git-fastclone/version.rb
@@ -2,5 +2,5 @@
 
 # Version string for git-fastclone
 module GitFastCloneVersion
-  VERSION = '1.4.1'
+  VERSION = '1.4.2'
 end

--- a/script/spec_demo_tool.sh
+++ b/script/spec_demo_tool.sh
@@ -1,0 +1,14 @@
+#/bin/bash
+
+# This script is a sample script used in integration tests that exits with the code passed as the first argument
+# Also, it prints all extra arguments
+
+exit_code="$1"
+
+if [ $# -gt 1 ]; then
+  # Skip first argument, which is the exit code
+  shift
+  echo "$@"
+fi
+
+exit $exit_code

--- a/spec/git_fastclone_runner_spec.rb
+++ b/spec/git_fastclone_runner_spec.rb
@@ -99,11 +99,11 @@ describe GitFastClone::Runner do
     it 'should clone correctly' do
       expect(subject).to receive(:fail_on_error).with(
         'git', 'checkout', '--quiet', 'PH',
-        { quiet: true }
+        { quiet: true, print_on_failure: false }
       ) { runner_execution_double }
       expect(subject).to receive(:fail_on_error).with(
         'git', 'clone', '--quiet', '--reference', '/cache', 'PH', '/pwd/.',
-        { quiet: true }
+        { quiet: true, print_on_failure: false }
       ) { runner_execution_double }
 
       subject.clone(placeholder_arg, placeholder_arg, '.', nil)
@@ -113,11 +113,11 @@ describe GitFastClone::Runner do
       subject.verbose = true
       expect(subject).to receive(:fail_on_error).with(
         'git', 'checkout', '--quiet', 'PH',
-        { quiet: false }
+        { quiet: false, print_on_failure: false }
       ) { runner_execution_double }
       expect(subject).to receive(:fail_on_error).with(
         'git', 'clone', '--verbose', '--reference', '/cache', 'PH', '/pwd/.',
-        { quiet: false }
+        { quiet: false, print_on_failure: false }
       ) { runner_execution_double }
 
       subject.clone(placeholder_arg, placeholder_arg, '.', nil)
@@ -126,10 +126,25 @@ describe GitFastClone::Runner do
     it 'should clone correctly with custom configs' do
       expect(subject).to receive(:fail_on_error).with(
         'git', 'clone', '--quiet', '--reference', '/cache', 'PH', '/pwd/.', '--config', 'config',
-        { quiet: true }
+        { quiet: true, print_on_failure: false }
       ) { runner_execution_double }
 
       subject.clone(placeholder_arg, nil, '.', 'config')
+    end
+
+    context 'with printing errors' do
+      before(:each) do
+        subject.print_git_errors = true
+      end
+
+      it 'prints failures' do
+        expect(subject).to receive(:fail_on_error).with(
+          'git', 'clone', '--quiet', '--reference', '/cache', 'PH', '/pwd/.', '--config', 'config',
+          { quiet: true, print_on_failure: true }
+        ) { runner_execution_double }
+
+        subject.clone(placeholder_arg, nil, '.', 'config')
+      end
     end
   end
 

--- a/spec/runner_execution_spec.rb
+++ b/spec/runner_execution_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Copyright 2023 Square Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'git-fastclone'
+
+# Integration tests use real demo_tool.sh to inspect the E2E behavior
+describe RunnerExecution do
+  subject { described_class }
+  let(:external_tool) { "#{__dir__}/../script/spec_demo_tool.sh" }
+  let(:logger) { double('logger') }
+
+  before do
+    allow($stdout).to receive(:puts)
+    allow(logger).to receive(:info)
+    allow(logger).to receive(:debug)
+    allow(logger).to receive(:warn)
+    allow(RunnerExecution).to receive(:logger).and_return(logger)
+  end
+
+  describe '.fail_on_error' do
+    it 'should log failure info on command error' do
+      expect(logger).to receive(:info).with("My error output\n")
+
+      expect do
+        described_class.fail_on_error(external_tool, '1', 'My error output', quiet: true,
+                                                                             print_on_failure: true)
+      end.to raise_error(RunnerExecution::RunnerExecutionRuntimeError)
+    end
+
+    it 'should not log failure output on command success' do
+      expect($stdout).not_to receive(:info)
+
+      described_class.fail_on_error(external_tool, '0', 'My success output', quiet: true,
+                                                                             print_on_failure: true)
+    end
+
+    it 'should not log failure output when not in the quiet mode' do
+      expect($stdout).not_to receive(:info)
+
+      described_class.fail_on_error(external_tool, '0', 'My success output', quiet: false,
+                                                                             print_on_failure: true)
+    end
+  end
+end


### PR DESCRIPTION
Introducing a mode that prints `git output` if a command fails.
* Pass `--print_git_errors` to enable that mode
* In the verbose mode is enabled, this argument is redundant (added a warning)
 
![image](https://github.com/square/git-fastclone/assets/9629417/4e4e3d49-cda3-4083-b25b-d2b975860726)

To test, invoke `git-fastclone  git@github.com:githubtraining/hellogitworld.git -b 1111 --print_git_errors ` which will try to check out to a non-existing `111`. 

```
git-fastclone 1.4.2
Cloning hellogitworld to ..../hellogitworld
I, [2023-06-27T12:41:07.545645 #90557]  INFO -- : error: pathspec '1111' did not match any file(s) known to git
```