### PR TITLE
Add a mode to print git errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [master]
   pull_request:
     branches: [master]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ["2.7.4", "3.1.3"]
+        experimental: [false]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+        # change this to (see https://github.com/ruby/setup-ruby#versioning):
+        # uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Run tests
+        run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language:
-  ruby
-
-rvm:
-  - 2.7.4
-  - 3.1.3
-
-before_install:
-  - gem install bundler -v 2.3.26

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git-fastclone (1.4.1)
+    git-fastclone (1.4.2)
       colorize
 
 GEM

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -135,10 +135,12 @@ module GitFastClone
         end
 
         opts.on('-v', '--verbose', 'Verbose mode') do
+          puts '--print_git_errors is redundant when using --verbose' if print_git_errors
           self.verbose = true
         end
 
         opts.on('--print_git_errors', 'Print git output if a command fails') do
+          puts '--print_git_errors is redundant when using --verbose' if verbose
           self.print_git_errors = true
         end
 

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -74,7 +74,7 @@ module GitFastClone
     DEFAULT_GIT_ALLOW_PROTOCOL = 'file:git:http:https:ssh'
 
     attr_accessor :reference_dir, :prefetch_submodules, :reference_updated, :reference_mutex,
-                  :options, :abs_clone_path, :using_local_repo, :verbose, :'print_git_errors', :color,
+                  :options, :abs_clone_path, :using_local_repo, :verbose, :print_git_errors, :color,
                   :flock_timeout_secs
 
     def initialize
@@ -138,7 +138,7 @@ module GitFastClone
           self.verbose = true
         end
 
-        opts.on('--print_git_errors', 'Print git command outputs when git command fails') do
+        opts.on('--print_git_errors', 'Print git output if a command fails') do
           self.print_git_errors = true
         end
 
@@ -224,7 +224,8 @@ module GitFastClone
       # Only checkout if we're changing branches to a non-default branch
       if rev
         Dir.chdir(File.join(abs_clone_path, src_dir)) do
-          fail_on_error('git', 'checkout', '--quiet', rev.to_s, quiet: !verbose, print_on_failure: print_git_errors)
+          fail_on_error('git', 'checkout', '--quiet', rev.to_s, quiet: !verbose,
+                                                                print_on_failure: print_git_errors)
         end
       end
 
@@ -249,7 +250,8 @@ module GitFastClone
       submodule_url_list = []
       output = ''
       Dir.chdir(File.join(abs_clone_path, pwd).to_s) do
-        output = fail_on_error('git', 'submodule', 'init', quiet: !verbose, print_on_failure: print_git_errors)
+        output = fail_on_error('git', 'submodule', 'init', quiet: !verbose,
+                                                           print_on_failure: print_git_errors)
       end
 
       output.split("\n").each do |line|

--- a/lib/git-fastclone/version.rb
+++ b/lib/git-fastclone/version.rb
@@ -2,5 +2,5 @@
 
 # Version string for git-fastclone
 module GitFastCloneVersion
-  VERSION = '1.4.1'
+  VERSION = '1.4.2'
 end

--- a/lib/runner_execution.rb
+++ b/lib/runner_execution.rb
@@ -22,7 +22,7 @@ module RunnerExecution
 
   # Runs a command that fails on error.
   # Uses popen2e wrapper. Handles bad statuses with potential for retries.
-  def fail_on_error(*cmd, stdin_data: nil, binmode: false, quiet: false, **opts)
+  def fail_on_error(*cmd, stdin_data: nil, binmode: false, quiet: false, print_on_failure: false, **opts)
     print_command('Running Shell Safe Command:', [cmd]) unless quiet
     shell_safe_cmd = shell_safe(cmd)
     retry_times = opts[:retry] || 0
@@ -39,7 +39,9 @@ module RunnerExecution
     end
 
     # Get out with the status, good or bad.
-    exit_on_status(output, [shell_safe_cmd], [status], quiet: quiet)
+    # When quiet, we don't need to print the output, as it is already streamed from popen2e_wrapper
+    exit_prints_on_failure = quiet && print_on_failure
+    exit_on_status(output, [shell_safe_cmd], [status], quiet: quiet, print_on_failure: exit_prints_on_failure)
   end
   module_function :fail_on_error
 
@@ -155,20 +157,22 @@ module RunnerExecution
   # return code of the first one.
   #
   # Otherwise returns first argument (output)
-  def exit_on_status(output, cmd_list, status_list, quiet: false)
+  def exit_on_status(output, cmd_list, status_list, quiet: false, print_on_failure: false)
     status_list.each_index do |index|
       status = status_list[index]
       cmd = cmd_list[index]
-      check_status(cmd, status, output: output, quiet: quiet)
+      # When quiet, we don't need to print the outputs, as they are already printed
+      check_status(cmd, status, output: output, quiet: quiet, print_on_failure: print_on_failure)
     end
 
     output
   end
   module_function :exit_on_status
 
-  def check_status(cmd, status, output: nil, quiet: false)
+  def check_status(cmd, status, output: nil, quiet: false, print_on_failure: false)
     return if status.exited? && status.exitstatus == 0
 
+    puts output if print_on_failure
     # If we exited nonzero or abnormally, print debugging info and explode.
     if status.exited?
       logger.debug("Process Exited normally. Exit status:#{status.exitstatus}") unless quiet

--- a/lib/runner_execution.rb
+++ b/lib/runner_execution.rb
@@ -40,8 +40,8 @@ module RunnerExecution
 
     # Get out with the status, good or bad.
     # When quiet, we don't need to print the output, as it is already streamed from popen2e_wrapper
-    exit_prints_on_failure = quiet && print_on_failure
-    exit_on_status(output, [shell_safe_cmd], [status], quiet: quiet, print_on_failure: exit_prints_on_failure)
+    needs_print_on_failure = quiet && print_on_failure
+    exit_on_status(output, [shell_safe_cmd], [status], quiet: quiet, print_on_failure: needs_print_on_failure)
   end
   module_function :fail_on_error
 
@@ -161,7 +161,6 @@ module RunnerExecution
     status_list.each_index do |index|
       status = status_list[index]
       cmd = cmd_list[index]
-      # When quiet, we don't need to print the outputs, as they are already printed
       check_status(cmd, status, output: output, quiet: quiet, print_on_failure: print_on_failure)
     end
 
@@ -172,7 +171,7 @@ module RunnerExecution
   def check_status(cmd, status, output: nil, quiet: false, print_on_failure: false)
     return if status.exited? && status.exitstatus == 0
 
-    puts output if print_on_failure
+    logger.info(output) if print_on_failure
     # If we exited nonzero or abnormally, print debugging info and explode.
     if status.exited?
       logger.debug("Process Exited normally. Exit status:#{status.exitstatus}") unless quiet

--- a/script/spec_demo_tool.sh
+++ b/script/spec_demo_tool.sh
@@ -1,0 +1,11 @@
+#/bin/bash
+
+# This script is a sample script used in tests that exists with the exit code passed as the first argument
+# It prints all arguemnts if more than 2 params are passed
+
+if [ $# -gt 1 ]; then
+  # {@:2} - Skip first argument, which is the exit code
+  echo "${@:2}"
+fi
+
+exit $1

--- a/script/spec_demo_tool.sh
+++ b/script/spec_demo_tool.sh
@@ -3,9 +3,12 @@
 # This script is a sample script used in integration tests that exits with the code passed as the first argument
 # Also, it prints all extra arguments
 
+exit_code="$1"
+
 if [ $# -gt 1 ]; then
-  # {@:2} - Skip first argument, which is the exit code
-  echo "${@:2}"
+  # Skip first argument, which is the exit code
+  shift
+  echo "$@"
 fi
 
-exit $1
+exit $exit_code

--- a/script/spec_demo_tool.sh
+++ b/script/spec_demo_tool.sh
@@ -1,7 +1,7 @@
 #/bin/bash
 
-# This script is a sample script used in tests that exists with the exit code passed as the first argument
-# It prints all arguemnts if more than 2 params are passed
+# This script is a sample script used in integration tests that exits with the code passed as the first argument
+# Also, it prints all extra arguments
 
 if [ $# -gt 1 ]; then
   # {@:2} - Skip first argument, which is the exit code

--- a/spec/git_fastclone_runner_spec.rb
+++ b/spec/git_fastclone_runner_spec.rb
@@ -126,10 +126,25 @@ describe GitFastClone::Runner do
     it 'should clone correctly with custom configs' do
       expect(subject).to receive(:fail_on_error).with(
         'git', 'clone', '--quiet', '--reference', '/cache', 'PH', '/pwd/.', '--config', 'config',
-        { quiet: true, print_on_failure: false}
+        { quiet: true, print_on_failure: false }
       ) { runner_execution_double }
 
       subject.clone(placeholder_arg, nil, '.', 'config')
+    end
+
+    context 'with printing errors' do
+      before(:each) do
+        subject.print_git_errors = true
+      end
+
+      it 'prints failures' do
+        expect(subject).to receive(:fail_on_error).with(
+          'git', 'clone', '--quiet', '--reference', '/cache', 'PH', '/pwd/.', '--config', 'config',
+          { quiet: true, print_on_failure: true }
+        ) { runner_execution_double }
+
+        subject.clone(placeholder_arg, nil, '.', 'config')
+      end
     end
   end
 

--- a/spec/git_fastclone_runner_spec.rb
+++ b/spec/git_fastclone_runner_spec.rb
@@ -99,11 +99,11 @@ describe GitFastClone::Runner do
     it 'should clone correctly' do
       expect(subject).to receive(:fail_on_error).with(
         'git', 'checkout', '--quiet', 'PH',
-        { quiet: true }
+        { quiet: true, print_on_failure: false }
       ) { runner_execution_double }
       expect(subject).to receive(:fail_on_error).with(
         'git', 'clone', '--quiet', '--reference', '/cache', 'PH', '/pwd/.',
-        { quiet: true }
+        { quiet: true, print_on_failure: false }
       ) { runner_execution_double }
 
       subject.clone(placeholder_arg, placeholder_arg, '.', nil)
@@ -113,11 +113,11 @@ describe GitFastClone::Runner do
       subject.verbose = true
       expect(subject).to receive(:fail_on_error).with(
         'git', 'checkout', '--quiet', 'PH',
-        { quiet: false }
+        { quiet: false, print_on_failure: false }
       ) { runner_execution_double }
       expect(subject).to receive(:fail_on_error).with(
         'git', 'clone', '--verbose', '--reference', '/cache', 'PH', '/pwd/.',
-        { quiet: false }
+        { quiet: false, print_on_failure: false }
       ) { runner_execution_double }
 
       subject.clone(placeholder_arg, placeholder_arg, '.', nil)
@@ -126,7 +126,7 @@ describe GitFastClone::Runner do
     it 'should clone correctly with custom configs' do
       expect(subject).to receive(:fail_on_error).with(
         'git', 'clone', '--quiet', '--reference', '/cache', 'PH', '/pwd/.', '--config', 'config',
-        { quiet: true }
+        { quiet: true, print_on_failure: false}
       ) { runner_execution_double }
 
       subject.clone(placeholder_arg, nil, '.', 'config')

--- a/spec/runner_execution_spec.rb
+++ b/spec/runner_execution_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Copyright 2023 Square Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'git-fastclone'
+
+# Integration tests use real demo_tool.sh to inspect the E2E behavior
+describe RunnerExecution do
+  subject { described_class }
+  let(:external_tool) { "#{__dir__}/../script/spec_demo_tool.sh" }
+  let(:logger) { double('logger') }
+
+  before do
+    allow($stdout).to receive(:puts)
+    allow(logger).to receive(:info)
+    allow(logger).to receive(:debug)
+    allow(logger).to receive(:warn)
+    allow(RunnerExecution).to receive(:logger).and_return(logger)
+  end
+
+  describe '.fail_on_error' do
+    it 'should log failure info on command error' do
+      expect(logger).to receive(:info).with("My error output\n")
+
+      expect do
+        described_class.fail_on_error(external_tool, '1', 'My error output', quiet: true,
+                                                                             print_on_failure: true)
+      end.to raise_error(RunnerExecution::RunnerExecutionRuntimeError)
+    end
+
+    it 'should not log failure output on command success' do
+      expect($stdout).not_to receive(:info)
+
+      described_class.fail_on_error(external_tool, '0', 'My success output', quiet: true,
+                                                                             print_on_failure: true)
+    end
+
+    it 'should not log failure output when not in the quiet mode' do
+      expect($stdout).not_to receive(:info)
+
+      described_class.fail_on_error(external_tool, '0', 'My success output', quiet: false,
+                                                                             print_on_failure: true)
+    end
+  end
+end


### PR DESCRIPTION
Rehashed #56 without fork-PR

Introducing a mode that prints `git output` if a command fails.
* Pass `--print_git_errors` to enable that mode
* In the verbose mode is enabled, this argument is redundant (added a warning)
 
![image](https://github.com/square/git-fastclone/assets/9629417/4e4e3d49-cda3-4083-b25b-d2b975860726)

To test, invoke `git-fastclone  git@github.com:githubtraining/hellogitworld.git -b 1111 --print_git_errors ` which will try to check out to a non-existing `111`. 

```
git-fastclone 1.4.2
Cloning hellogitworld to ..../hellogitworld
I, [2023-06-27T12:41:07.545645 #90557]  INFO -- : error: pathspec '1111' did not match any file(s) known to git
```