### PR TITLE
Move CI to GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ["2.7.4", "3.1.3"]
+        experimental: [false]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+        # change this to (see https://github.com/ruby/setup-ruby#versioning):
+        # uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Run rake
+        run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language:
-  ruby
-
-rvm:
-  - 2.7.4
-  - 3.1.3
-
-before_install:
-  - gem install bundler -v 2.3.26


### PR DESCRIPTION
Travis is no longer supported.

_The configuration is inspired by https://github.com/square/square-ruby-sdk/blob/master/.github/workflows/ruby.yml_


### Next steps

Set branch protection for `CI / test`