### PR TITLE
Replace all places that can call `Dir.chdir` in thread with passing `chdir` to `Open3.popen2e`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git-fastclone (1.4.2)
+    git-fastclone (1.4.3)
       colorize
 
 GEM

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -270,7 +270,6 @@ module GitFastClone
     def thread_update_submodule(submodule_url, submodule_path, threads, pwd)
       threads << Thread.new do
         with_git_mirror(submodule_url) do |mirror, _|
-          fail_on_error(['cd', File.join(abs_clone_path, pwd).to_s], quiet: !verbose)
           cmd = ['cd', File.join(abs_clone_path, pwd).to_s, '&&', 'git', 'submodule',
                  verbose ? nil : '--quiet', 'update', '--reference', mirror.to_s, submodule_path.to_s].compact
           fail_on_error(*cmd, quiet: !verbose, print_on_failure: print_git_errors)

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -225,9 +225,9 @@ module GitFastClone
 
       # Only checkout if we're changing branches to a non-default branch
       if rev
-          fail_on_error('git', 'checkout', '--quiet', rev.to_s, quiet: !verbose,
-                                                                print_on_failure: print_git_errors,
-                                                              :chdir => File.join(abs_clone_path, src_dir))
+        fail_on_error('git', 'checkout', '--quiet', rev.to_s, quiet: !verbose,
+                                                              print_on_failure: print_git_errors,
+                                                              chdir: File.join(abs_clone_path, src_dir))
       end
 
       update_submodules(src_dir, url)
@@ -251,8 +251,8 @@ module GitFastClone
       submodule_url_list = []
       output = ''
       output = fail_on_error('git', 'submodule', 'init', quiet: !verbose,
-                                                          print_on_failure: print_git_errors,
-                                                          :chdir => File.join(abs_clone_path, pwd))
+                                                         print_on_failure: print_git_errors,
+                                                         chdir: File.join(abs_clone_path, pwd))
 
       output.split("\n").each do |line|
         submodule_path, submodule_url = parse_update_info(line)
@@ -270,7 +270,8 @@ module GitFastClone
         with_git_mirror(submodule_url) do |mirror, _|
           cmd = ['git', 'submodule',
                  verbose ? nil : '--quiet', 'update', '--reference', mirror.to_s, submodule_path.to_s].compact
-          fail_on_error(*cmd, quiet: !verbose, print_on_failure: print_git_errors, :chdir => File.join(abs_clone_path, pwd))
+          fail_on_error(*cmd, quiet: !verbose, print_on_failure: print_git_errors,
+                              chdir: File.join(abs_clone_path, pwd))
         end
 
         update_submodules(File.join(pwd, submodule_path), submodule_url)
@@ -347,7 +348,7 @@ module GitFastClone
       end
 
       cmd = ['git', 'remote', verbose ? '--verbose' : nil, 'update', '--prune'].compact
-      fail_on_error(*cmd, quiet: !verbose, print_on_failure: print_git_errors, :chdir => mirror)
+      fail_on_error(*cmd, quiet: !verbose, print_on_failure: print_git_errors, chdir: mirror)
 
       reference_updated[repo_name] = true
     rescue RunnerExecutionRuntimeError => e

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -248,6 +248,7 @@ module GitFastClone
 
       puts 'Updating submodules...' if verbose
 
+      threads = []
       submodule_url_list = []
       output = ''
       Dir.chdir(File.join(abs_clone_path, pwd).to_s) do
@@ -259,19 +260,23 @@ module GitFastClone
         submodule_path, submodule_url = parse_update_info(line)
         submodule_url_list << submodule_url
 
+        thread_update_submodule(submodule_url, submodule_path, threads, pwd)
+      end
 
+      update_submodule_reference(url, submodule_url_list)
+      threads.each(&:join)
+    end
+
+    def thread_update_submodule(submodule_url, submodule_path, threads, pwd)
+      threads << Thread.new do
         with_git_mirror(submodule_url) do |mirror, _|
-          Dir.chdir(File.join(abs_clone_path, pwd).to_s) do
-            cmd = ['git', 'submodule', verbose ? nil : '--quiet', 'update', '--reference', mirror.to_s,
-                   submodule_path.to_s].compact
-            fail_on_error(*cmd, quiet: !verbose, print_on_failure: print_git_errors)
-          end
+          cmd = ['cd', File.join(abs_clone_path, pwd).to_s, '&&', 'git', 'submodule',
+                 verbose ? nil : '--quiet', 'update', '--reference', mirror.to_s, submodule_path.to_s].compact
+          fail_on_error(*cmd, quiet: !verbose, print_on_failure: print_git_errors)
         end
 
         update_submodules(File.join(pwd, submodule_path), submodule_url)
       end
-
-      update_submodule_reference(url, submodule_url_list)
     end
 
     def with_reference_repo_lock(url, &block)
@@ -330,7 +335,8 @@ module GitFastClone
     # Grab the children in the event of a prefetch
     def prefetch(submodule_file)
       File.readlines(submodule_file).each do |line|
-        update_reference_repo(line.strip, false)
+        # We don't join these threads explicitly
+        Thread.new { update_reference_repo(line.strip, false) }
       end
     end
 
@@ -341,10 +347,9 @@ module GitFastClone
         fail_on_error('git', 'clone', verbose ? '--verbose' : '--quiet', '--mirror', url.to_s, mirror.to_s,
                       quiet: !verbose, print_on_failure: print_git_errors)
       end
-      Dir.chdir(mirror) do
-        cmd = ['git', 'remote', verbose ? '--verbose' : nil, 'update', '--prune'].compact
-        fail_on_error(*cmd, quiet: !verbose, print_on_failure: print_git_errors)
-      end
+
+      cmd = ['cd', mirror, '&&', 'git', 'remote', verbose ? '--verbose' : nil, 'update', '--prune'].compact
+      fail_on_error(*cmd, quiet: !verbose, print_on_failure: print_git_errors)
 
       reference_updated[repo_name] = true
     rescue RunnerExecutionRuntimeError => e

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -249,7 +249,6 @@ module GitFastClone
 
       threads = []
       submodule_url_list = []
-      output = ''
       output = fail_on_error('git', 'submodule', 'init', quiet: !verbose,
                                                          print_on_failure: print_git_errors,
                                                          chdir: File.join(abs_clone_path, pwd))

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -270,11 +270,10 @@ module GitFastClone
     def thread_update_submodule(submodule_url, submodule_path, threads, pwd)
       threads << Thread.new do
         with_git_mirror(submodule_url) do |mirror, _|
-          Dir.chdir(File.join(abs_clone_path, pwd).to_s) do
-            cmd = ['git', 'submodule', verbose ? nil : '--quiet', 'update', '--reference', mirror.to_s,
-                   submodule_path.to_s].compact
-            fail_on_error(*cmd, quiet: !verbose, print_on_failure: print_git_errors)
-          end
+          fail_on_error(['cd', File.join(abs_clone_path, pwd).to_s], quiet: !verbose)
+          cmd = ['cd', File.join(abs_clone_path, pwd).to_s, '&&', 'git', 'submodule', verbose ? nil : '--quiet', 'update', '--reference', mirror.to_s,
+                  submodule_path.to_s].compact
+          fail_on_error(*cmd, quiet: !verbose, print_on_failure: print_git_errors)
         end
 
         update_submodules(File.join(pwd, submodule_path), submodule_url)
@@ -350,10 +349,9 @@ module GitFastClone
                       quiet: !verbose, print_on_failure: print_git_errors)
       end
 
-      Dir.chdir(mirror) do
-        cmd = ['git', 'remote', verbose ? '--verbose' : nil, 'update', '--prune'].compact
-        fail_on_error(*cmd, quiet: !verbose, print_on_failure: print_git_errors)
-      end
+      cmd = ['cd', mirror, '&&', 'git', 'remote', verbose ? '--verbose' : nil, 'update', '--prune'].compact
+      fail_on_error(*cmd, quiet: !verbose, print_on_failure: print_git_errors)
+
       reference_updated[repo_name] = true
     rescue RunnerExecutionRuntimeError => e
       # To avoid corruption of the cache, if we failed to update or check out we remove

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -271,8 +271,8 @@ module GitFastClone
       threads << Thread.new do
         with_git_mirror(submodule_url) do |mirror, _|
           fail_on_error(['cd', File.join(abs_clone_path, pwd).to_s], quiet: !verbose)
-          cmd = ['cd', File.join(abs_clone_path, pwd).to_s, '&&', 'git', 'submodule', verbose ? nil : '--quiet', 'update', '--reference', mirror.to_s,
-                  submodule_path.to_s].compact
+          cmd = ['cd', File.join(abs_clone_path, pwd).to_s, '&&', 'git', 'submodule',
+                 verbose ? nil : '--quiet', 'update', '--reference', mirror.to_s, submodule_path.to_s].compact
           fail_on_error(*cmd, quiet: !verbose, print_on_failure: print_git_errors)
         end
 

--- a/lib/git-fastclone/version.rb
+++ b/lib/git-fastclone/version.rb
@@ -2,5 +2,5 @@
 
 # Version string for git-fastclone
 module GitFastCloneVersion
-  VERSION = '1.4.2'
+  VERSION = '1.4.3'
 end

--- a/spec/git_fastclone_runner_spec.rb
+++ b/spec/git_fastclone_runner_spec.rb
@@ -404,7 +404,8 @@ describe GitFastClone::Runner do
       [
         ['git', 'clone', verbose ? '--verbose' : '--quiet', '--mirror', test_url_valid,
          test_reference_repo_dir],
-        ['cd', test_reference_repo_dir, '&&', 'git', 'remote', verbose ? '--verbose' : nil, 'update', '--prune'].compact
+        ['cd', test_reference_repo_dir, '&&', 'git', 'remote', verbose ? '--verbose' : nil, 'update',
+         '--prune'].compact
       ]
     end
 

--- a/spec/git_fastclone_runner_spec.rb
+++ b/spec/git_fastclone_runner_spec.rb
@@ -404,7 +404,7 @@ describe GitFastClone::Runner do
       [
         ['git', 'clone', verbose ? '--verbose' : '--quiet', '--mirror', test_url_valid,
          test_reference_repo_dir],
-        ['git', 'remote', verbose ? '--verbose' : nil, 'update', '--prune'].compact
+        ['cd', test_reference_repo_dir, '&&', 'git', 'remote', verbose ? '--verbose' : nil, 'update', '--prune'].compact
       ]
     end
 

--- a/spec/git_fastclone_runner_spec.rb
+++ b/spec/git_fastclone_runner_spec.rb
@@ -91,7 +91,6 @@ describe GitFastClone::Runner do
     before(:each) do
       allow(runner_execution_double).to receive(:fail_on_error) {}
       allow(Dir).to receive(:pwd) { '/pwd' }
-      allow(Dir).to receive(:chdir).and_yield
       allow(subject).to receive(:with_git_mirror).and_yield('/cache', 0)
       expect(subject).to receive(:clear_clone_dest_if_needed).once {}
     end
@@ -99,7 +98,7 @@ describe GitFastClone::Runner do
     it 'should clone correctly' do
       expect(subject).to receive(:fail_on_error).with(
         'git', 'checkout', '--quiet', 'PH',
-        { quiet: true, print_on_failure: false }
+        { chdir: '/pwd/.', print_on_failure: false, quiet: true }
       ) { runner_execution_double }
       expect(subject).to receive(:fail_on_error).with(
         'git', 'clone', '--quiet', '--reference', '/cache', 'PH', '/pwd/.',
@@ -113,7 +112,7 @@ describe GitFastClone::Runner do
       subject.verbose = true
       expect(subject).to receive(:fail_on_error).with(
         'git', 'checkout', '--quiet', 'PH',
-        { quiet: false, print_on_failure: false }
+        { chdir: '/pwd/.', print_on_failure: false, quiet: false }
       ) { runner_execution_double }
       expect(subject).to receive(:fail_on_error).with(
         'git', 'clone', '--verbose', '--reference', '/cache', 'PH', '/pwd/.',
@@ -338,7 +337,6 @@ describe GitFastClone::Runner do
 
     it 'should correctly update the hash' do
       allow(subject).to receive(:fail_on_error)
-      allow(Dir).to receive(:chdir) {}
 
       subject.reference_updated = placeholder_hash
       subject.store_updated_repo(placeholder_arg, placeholder_arg, placeholder_arg, false)
@@ -389,7 +387,6 @@ describe GitFastClone::Runner do
         expected_command = expected_commands.shift
         expect(command).to eq(expected_command)
       }
-      allow(Dir).to receive(:chdir).and_yield
 
       allow(subject).to receive(:print_formatted_error) {}
       allow(subject).to receive(:reference_repo_dir).and_return(test_reference_repo_dir)
@@ -404,7 +401,7 @@ describe GitFastClone::Runner do
       [
         ['git', 'clone', verbose ? '--verbose' : '--quiet', '--mirror', test_url_valid,
          test_reference_repo_dir],
-        ['cd', test_reference_repo_dir, '&&', 'git', 'remote', verbose ? '--verbose' : nil, 'update',
+        ['git', 'remote', verbose ? '--verbose' : nil, 'update',
          '--prune'].compact
       ]
     end


### PR DESCRIPTION
This elimiates the `warning: "conflicting chdir during another chdir block"` introduced in `1.4.0` so it can now run smoothly in Ruby 3 instead of throwing exception because of https://bugs.ruby-lang.org/issues/15661

Tested with a repro case on our side that is no longer failing with ruby 3.
And submodules are cloned fine since `git submodule status` shows correct refs for each and the repo size is correct. (If not done correctly, checkout will happen too quick and final repo size will be too small)