### PR TITLE
Don't clear cache if an error was authentication-related

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.7.4", "3.1.3"]
+        ruby-version: ["2.7.4", "3.1.4", "3.2.2"]
         experimental: [false]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
         # change this to (see https://github.com/ruby/setup-ruby#versioning):

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["2.7.4", "3.1.4", "3.2.2"]
+        ruby-version: ["2.7.4", "3.0.6", "3.1.4", "3.2.2", "3.3.0-preview3"]
         experimental: [false]
     steps:
       - uses: actions/checkout@v4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,53 +1,54 @@
 PATH
   remote: .
   specs:
-    git-fastclone (1.4.3)
+    git-fastclone (1.4.4)
       colorize
 
 GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
-    colorize (0.8.1)
+    colorize (1.1.0)
     diff-lcs (1.5.0)
     json (2.6.3)
-    parallel (1.22.1)
-    parser (3.1.3.0)
+    language_server-protocol (3.17.0.3)
+    parallel (1.23.0)
+    parser (3.2.2.4)
       ast (~> 2.4.1)
+      racc
+    racc (1.7.3)
     rainbow (3.1.1)
-    rake (13.0.6)
-    regexp_parser (2.6.1)
-    rexml (3.2.5)
+    rake (13.1.0)
+    regexp_parser (2.8.2)
+    rexml (3.2.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
       rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.0)
+    rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.0)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.0)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
-    rubocop (1.39.0)
+    rspec-support (3.12.1)
+    rubocop (1.57.2)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.1.2.1)
+      parser (>= 3.2.2.4)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.23.0, < 2.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.24.0)
-      parser (>= 3.1.1.0)
-    ruby-progressbar (1.11.0)
-    unicode-display_width (2.3.0)
-
-PLATFORMS
-  ruby
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (2.5.0)
 
 DEPENDENCIES
   bundler
@@ -57,4 +58,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.3.26
+   2.4.20

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,10 @@ GEM
     ruby-progressbar (1.13.0)
     unicode-display_width (2.5.0)
 
+PLATFORMS
+  arm64-darwin-23
+  x86_64-linux
+
 DEPENDENCIES
   bundler
   git-fastclone!

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -110,7 +110,7 @@ module GitFastClone
     def run
       url, path, options = parse_inputs
 
-      require_relative './git-fastclone/version'
+      require_relative 'git-fastclone/version'
       msg = "git-fastclone #{GitFastCloneVersion::VERSION}"
       if color
         puts msg.yellow
@@ -354,8 +354,15 @@ module GitFastClone
       # To avoid corruption of the cache, if we failed to update or check out we remove
       # the cache directory entirely. This may cause the current clone to fail, but if the
       # underlying error from git is transient it will not affect future clones.
-      clear_cache(mirror, url)
+      #
+      # The only exception to this is authentication failures, because they are transient,
+      # usually due to either a remote server outage or a local credentials config problem.
+      clear_cache(mirror, url) unless auth_error?(e.output)
       raise e if fail_hard
+    end
+
+    def auth_error?(error)
+      error.to_s =~ /.*^fatal: Authentication failed/m
     end
 
     def retriable_error?(error)

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -373,7 +373,8 @@ module GitFastClone
         /^fatal: pack has \d+ unresolved delta/,
         /^error: unable to read sha1 file of /,
         /^fatal: did not receive expected object/,
-        /^fatal: unable to read tree [a-z0-9]+\n^warning: Clone succeeded, but checkout failed/
+        /^fatal: unable to read tree [a-z0-9]+\n^warning: Clone succeeded, but checkout failed/,
+        /^fatal: Authentication failed/
       ]
       error.to_s =~ /.*#{Regexp.union(error_strings)}/m
     end

--- a/lib/git-fastclone/version.rb
+++ b/lib/git-fastclone/version.rb
@@ -2,5 +2,5 @@
 
 # Version string for git-fastclone
 module GitFastCloneVersion
-  VERSION = '1.4.3'
+  VERSION = '1.4.4'
 end


### PR DESCRIPTION
Sometimes there is issues with authentication (machine config or github.com issue), and I think we don't want this to be the reason that the cache is ever cleared.

This adds a new method to specifically handle an auth-related error, and also allows such errors to be retry-able (as they are sometimes transient).

Also CI was red but it seemed like Ruby env issues, so updating things on that front too.
