### PR TITLE
Add windows support for git-fastclone

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,9 +15,6 @@ Lint/EmptyBlock:
 Metrics/ClassLength:
   Max: 10000
 
-Metrics/LineLength:
-  Max: 110
-
 Metrics/AbcSize:
   Enabled: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES
@@ -62,4 +63,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.4.20
+   2.4.22

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -49,10 +49,10 @@ module GitFastClone
 
     def reference_filename(filename)
       separator = if RbConfig::CONFIG['host_os'] =~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/
-                              '__'
-                            else
-                              ':'
-                            end
+                    '__'
+                  else
+                    ':'
+                  end
       "#{separator}#{filename}"
     end
     module_function :reference_filename

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -63,7 +63,7 @@ module GitFastClone
     module_function :reference_repo_submodule_file
 
     def reference_repo_lock_file(url, reference_dir, using_local_repo)
-      lock_file_name = "#{reference_repo_dir(url, reference_dir, using_local_repo)}#{reference_filename('lock')}" # rubocop:disable Layout/LineLength
+      lock_file_name = "#{reference_repo_dir(url, reference_dir, using_local_repo)}#{reference_filename('lock')}"
       File.open(lock_file_name, File::RDWR | File::CREAT, 0o644)
     end
     module_function :reference_repo_lock_file

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -48,12 +48,12 @@ module GitFastClone
     module_function :reference_repo_dir
 
     def reference_filename(filename)
-      portation_character = if RbConfig::CONFIG['host_os'] =~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/
-                              '_'
+      separator = if RbConfig::CONFIG['host_os'] =~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+                              '__'
                             else
                               ':'
                             end
-      "#{portation_character}#{filename}"
+      "#{separator}#{filename}"
     end
     module_function :reference_filename
 

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -47,13 +47,23 @@ module GitFastClone
     end
     module_function :reference_repo_dir
 
+    def reference_filename(filename)
+      portation_character = if RbConfig::CONFIG['host_os'] =~ /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+                              '_'
+                            else
+                              ':'
+                            end
+      "#{portation_character}#{filename}"
+    end
+    module_function :reference_filename
+
     def reference_repo_submodule_file(url, reference_dir, using_local_repo)
-      "#{reference_repo_dir(url, reference_dir, using_local_repo)}:submodules.txt"
+      "#{reference_repo_dir(url, reference_dir, using_local_repo)}#{reference_filename('submodules.txt')}"
     end
     module_function :reference_repo_submodule_file
 
     def reference_repo_lock_file(url, reference_dir, using_local_repo)
-      lock_file_name = "#{reference_repo_dir(url, reference_dir, using_local_repo)}:lock"
+      lock_file_name = "#{reference_repo_dir(url, reference_dir, using_local_repo)}#{reference_filename('lock')}" # rubocop:disable Layout/LineLength
       File.open(lock_file_name, File::RDWR | File::CREAT, 0o644)
     end
     module_function :reference_repo_lock_file


### PR DESCRIPTION
Created a new function for the path generation that validates the current operation system before generating the path, and uses underscore in-case a windows system is being used to make sure git-fastclone doesn't use a non-allowed characters for windows filenames that prevents the submodules and lock files from being created