### PR TITLE
Add pre-cloning-hook for mirror-prepolulation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git-fastclone (1.4.5)
+    git-fastclone (1.5.0)
       colorize
 
 GEM

--- a/README.md
+++ b/README.md
@@ -43,16 +43,28 @@ Usage
     gem install git-fastclone
     git fastclone [options] <git-repo-url>
 
-    -b, --branch <branch>   Clone a specific branch
-    -v, --verbose           Verbose mode
-    -c, --color             Display colored output
-        --config CONFIG     Git config applied to the cloned repo
-        --lock-timeout N    Timeout in seconds to acquire a lock on any reference repo.
+    -b, --branch BRANCH              Checkout this branch rather than the default
+    -v, --verbose                    Verbose mode
+        --print_git_errors           Print git output if a command fails
+    -c, --color                      Display colored output
+        --config CONFIG              Git config applied to the cloned repo
+        --lock-timeout N             Timeout in seconds to acquire a lock on any reference repo.
+                Default is 0 which waits indefinitely.
+        --pre-clone-hook command     An optional command that should be invoked before cloning mirror repo
 
 Change the default `REFERENCE_REPO_DIR` environment variable if necessary.
 
 Cygwin users need to add `~/bin` to PATH.
 
+
+Hooks
+-----
+
+- `pre-clone-hook` is invoked right before cloning a new mirror repo, which gives a change to prepopulate git's mirror from a different source.
+The hook is invoked with given arguments:
+1. cloning repo url
+1. path to the repo mirror location
+1. attempt number, 0-indexed
 
 How to test?
 ------------

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -356,7 +356,7 @@ module GitFastClone
     # Creates or updates the mirror repo then stores an indication
     # that this repo has been updated on this run of fastclone
     def store_updated_repo(url, mirror, repo_name, fail_hard, attempt_number)
-      trigger_pre_clone_hook(url, mirror, attempt_number) unless unless Dir.exist?(mirror)
+      trigger_pre_clone_hook(url, mirror, attempt_number) unless Dir.exist?(mirror)
       # If pre_clone_hook correctly creates a mirror directory, we don't want to clone, but just update it
       unless Dir.exist?(mirror)
         fail_on_error('git', 'clone', verbose ? '--verbose' : '--quiet', '--mirror', url.to_s, mirror.to_s,

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -356,7 +356,7 @@ module GitFastClone
     # Creates or updates the mirror repo then stores an indication
     # that this repo has been updated on this run of fastclone
     def store_updated_repo(url, mirror, repo_name, fail_hard, attempt_number)
-      trigger_pre_clone_hook(url, mirror, attempt_number) unless Dir.exist?(mirror)
+      trigger_pre_clone_hook_if_needed(url, mirror, attempt_number)
       # If pre_clone_hook correctly creates a mirror directory, we don't want to clone, but just update it
       unless Dir.exist?(mirror)
         fail_on_error('git', 'clone', verbose ? '--verbose' : '--quiet', '--mirror', url.to_s, mirror.to_s,
@@ -449,8 +449,8 @@ module GitFastClone
       'Usage: git fastclone [options] <git-url> [path]'
     end
 
-    private def trigger_pre_clone_hook(url, mirror, attempt_number)
-      return unless options.include?(:pre_clone_hook)
+    private def trigger_pre_clone_hook_if_needed(url, mirror, attempt_number)
+      return if Dir.exist?(mirror) || !options.include?(:pre_clone_hook)
 
       popen2e_wrapper(options[:pre_clone_hook], url.to_s, mirror.to_s, attempt_number.to_s, quiet: !verbose)
     end

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -356,7 +356,7 @@ module GitFastClone
     # Creates or updates the mirror repo then stores an indication
     # that this repo has been updated on this run of fastclone
     def store_updated_repo(url, mirror, repo_name, fail_hard, attempt_number)
-      trigger_pre_clone_hook(url, mirror, attempt_number)
+      trigger_pre_clone_hook(url, mirror, attempt_number) unless unless Dir.exist?(mirror)
       # If pre_clone_hook correctly creates a mirror directory, we don't want to clone, but just update it
       unless Dir.exist?(mirror)
         fail_on_error('git', 'clone', verbose ? '--verbose' : '--quiet', '--mirror', url.to_s, mirror.to_s,
@@ -450,9 +450,9 @@ module GitFastClone
     end
 
     private def trigger_pre_clone_hook(url, mirror, attempt_number)
-      return if Dir.exist?(mirror) || !options.include?(:pre_clone_hook)
+      return unless options.include?(:pre_clone_hook)
 
-      popen2e_wrapper(options[:pre_clone_hook], url, mirror, attempt_number.to_s, quiet: !verbose)
+      popen2e_wrapper(options[:pre_clone_hook], url.to_s, mirror.to_s, attempt_number.to_s, quiet: !verbose)
     end
   end
 end

--- a/lib/git-fastclone/version.rb
+++ b/lib/git-fastclone/version.rb
@@ -2,5 +2,5 @@
 
 # Version string for git-fastclone
 module GitFastCloneVersion
-  VERSION = '1.4.5'
+  VERSION = '1.5.0'
 end


### PR DESCRIPTION
Introducing a new parameter (`--pre-clone-hook`) that is called before cloning a repo to the mirror.
This feature gives users the opportunity to prepopulate git's mirror from a different source. 


## Before merging:

* validate if the attempt number is incremented (set to 1+) if a git inconsistency happens is recognized at the beginning of the `git-fastclone` flow. ie. provide a way to indicate if the hook was already triggered in a previous attempt.