### PR TITLE
Skip clone warming up when a file is missing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git-fastclone (1.5.0)
+    git-fastclone (1.5.1)
       colorize
 
 GEM

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -162,13 +162,14 @@ module GitFastClone
           options[:config] = config
         end
 
-        opts.on('--lock-timeout N', 'Timeout in seconds to acquire a lock on any reference repo.
-                Default is 0 which waits indefinitely.') do |timeout_secs|
+        opts.on('--lock-timeout N', 'Timeout in seconds to acquire a lock on any reference repo.',
+                'Default is 0 which waits indefinitely.') do |timeout_secs|
           self.flock_timeout_secs = timeout_secs.to_i
         end
 
         opts.on('--pre-clone-hook script_file',
-                'An optional file that should be invoked before cloning mirror repo. No-op when a file is missing') do |script_file|
+                'An optional file that should be invoked before cloning mirror repo',
+                'No-op when a file is missing') do |script_file|
           options[:pre_clone_hook] = script_file
         end
       end.parse!

--- a/lib/git-fastclone/version.rb
+++ b/lib/git-fastclone/version.rb
@@ -2,5 +2,5 @@
 
 # Version string for git-fastclone
 module GitFastCloneVersion
-  VERSION = '1.5.0'
+  VERSION = '1.5.1'
 end


### PR DESCRIPTION
Follow-up to #66.
If a pre-warm script is missing, gracefully skip that step. That would make the calling API simpler I think.


### Tested

#### After 
```
REFERENCE_REPO_DIR=/tmp/my_test ruby -Ilib bin/git-fastclone    some_repo_path.git  --pre-clone-hook non_existing_file 
git-fastclone 1.5.1
Cloning to /Users/bartosz/Development/git-fastclone/some_repo_path
```

#### Before

```
REFERENCE_REPO_DIR=/tmp/my_test ruby -Ilib bin/git-fastclone    some_repo_path.git  --pre-clone-hook non_existing_file 
git-fastclone 1.5.1
Cloning to /Users/bartosz/Development/git-fastclone/some_repo_path

/Users/bartosz/.rvm/rubies/ruby-3.2.2/lib/ruby/3.2.0/open3.rb:222:in `spawn': No such file or directory - aaa (Errno::ENOENT)
	from /Users/bartosz/.rvm/rubies/ruby-3.2.2/lib/ruby/3.2.0/open3.rb:222:in `popen_run'
	from /Users/bartosz/.rvm/rubies/ruby-3.2.2/lib/ruby/3.2.0/open3.rb:210:in `popen2e'
...
```

