### PR TITLE
Add `--shared` flag when using sparse checkout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *:lock
 *.gem
+Gemfile.lock

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -253,6 +253,8 @@ module GitFastClone
 
         clone_commands = ['git', 'clone', verbose ? '--verbose' : '--quiet']
         # For sparse checkouts, clone directly from the local mirror and skip the actual checkout process
+        # --shared is included so that the checkout remains fast even if the reference and destination directories
+        #          live on different filesystem volumes.
         # For normal clones, use --reference and clone from the remote URL
         if sparse_paths
           clone_commands.push('--no-checkout', '--shared')

--- a/lib/git-fastclone.rb
+++ b/lib/git-fastclone.rb
@@ -255,7 +255,7 @@ module GitFastClone
         # For sparse checkouts, clone directly from the local mirror and skip the actual checkout process
         # For normal clones, use --reference and clone from the remote URL
         if sparse_paths
-          clone_commands.push('--no-checkout')
+          clone_commands.push('--no-checkout', '--shared')
           clone_commands << mirror.to_s << clone_dest
         else
           clone_commands << '--reference' << mirror.to_s << url.to_s << clone_dest

--- a/lib/git-fastclone/version.rb
+++ b/lib/git-fastclone/version.rb
@@ -2,5 +2,5 @@
 
 # Version string for git-fastclone
 module GitFastCloneVersion
-  VERSION = '1.6.0'
+  VERSION = '1.6.1'
 end

--- a/spec/git_fastclone_runner_spec.rb
+++ b/spec/git_fastclone_runner_spec.rb
@@ -145,6 +145,47 @@ describe GitFastClone::Runner do
       end
     end
 
+    context 'with sparse checkout' do
+      before(:each) do
+        subject.sparse_paths = %w[path1 path2]
+      end
+
+      it 'should clone with --no-checkout and --shared flags' do
+        expect(subject).to receive(:fail_on_error).with(
+          'git', 'clone', '--quiet', '--no-checkout', '--shared', '/cache', '/pwd/.',
+          { quiet: true, print_on_failure: false }
+        ) { runner_execution_double }
+        expect(subject).to receive(:perform_sparse_checkout).with('/pwd/.', 'PH')
+
+        subject.clone(placeholder_arg, 'PH', '.', nil)
+      end
+
+      it 'should clone with verbose mode and --shared flag' do
+        subject.verbose = true
+        expect(subject).to receive(:fail_on_error).with(
+          'git', 'clone', '--verbose', '--no-checkout', '--shared', '/cache', '/pwd/.',
+          { quiet: false, print_on_failure: false }
+        ) { runner_execution_double }
+        expect(subject).to receive(:perform_sparse_checkout).with('/pwd/.', 'PH')
+
+        subject.clone(placeholder_arg, 'PH', '.', nil)
+      end
+
+      it 'should not perform regular checkout when sparse checkout is enabled' do
+        expect(subject).to receive(:fail_on_error).with(
+          'git', 'clone', '--quiet', '--no-checkout', '--shared', '/cache', '/pwd/.',
+          { quiet: true, print_on_failure: false }
+        ) { runner_execution_double }
+        expect(subject).to receive(:perform_sparse_checkout).with('/pwd/.', 'PH')
+        expect(subject).not_to receive(:fail_on_error).with(
+          'git', 'checkout', '--quiet', 'PH',
+          anything
+        )
+
+        subject.clone(placeholder_arg, 'PH', '.', nil)
+      end
+    end
+
     context 'with pre-clone-hook' do
       let(:pre_clone_hook) { '/some/command' }
       before(:each) do


### PR DESCRIPTION
In an earlier test of the `--sparse-paths` feature I had kept the `--shared` flag to be used for the sparse checkout, but removed it because when testing on my local Mac it didn't seem to improve the speed.

**But**, using `--shared` greatly improves speed on systems where the reference Git clone is not the same as the destination checkout directory.

`--shared` creates an "alternates" file at `.git/objects/info/alternates` that just contains a path that points back to the original reference repo location.

Without `--shared`, if Git can't use a shallow copy mechanism, it will make a full copy of the entire  `.git` directory contents from the reference clone, potentially taking minutes for a very large repo.
